### PR TITLE
feat(auth): implement email-change verification, change-password, and token refactor

### DIFF
--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -4,7 +4,8 @@ import {
   RegistrationStartSchema,
   CompleteRegistrationSchema,
   ForgotPasswordSchema,
-  changePasswordPassword,
+  ResetPasswordWithTokenSchema,
+  changePasswordSchema,
 } from "@repo/schemas";
 import { NextFunction, Request, Response } from "express";
 import { AuthService } from "@/services/auth.service.js";
@@ -89,11 +90,8 @@ export class AuthController {
     next: NextFunction
   ) => {
     try {
-      const data = changePasswordPassword.parse(request.body);
-      await this.passwordResetService.resetPasswordWithToken(
-        data.token,
-        data.password
-      );
+      const data = ResetPasswordWithTokenSchema.parse(request.body);
+      await this.passwordResetService.resetPasswordWithToken(data);
       response.status(200).json({ message: "Password changed successfully" });
     } catch (error) {
       next(error);
@@ -137,6 +135,20 @@ export class AuthController {
       response.status(200).json({
         message: "Profile updated successfully",
       });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  changePassword = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const data = changePasswordSchema.parse(request.body);
+      await this.authService.changePassword(request.user.id, data);
+      response.status(200).json({ message: "Password changed successfully" });
     } catch (error) {
       next(error);
     }

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -11,6 +11,7 @@ import { NextFunction, Request, Response } from "express";
 import { AuthService } from "@/services/auth.service.js";
 import { FileService } from "@/services/file.service.js";
 import { PasswordResetService } from "@/services/password.service.js";
+import { changeEmailRequestSchema, changeEmailSchema } from "@repo/schemas";
 
 export class AuthController {
   private authService = new AuthService();
@@ -149,6 +150,34 @@ export class AuthController {
       const data = changePasswordSchema.parse(request.body);
       await this.authService.changePassword(request.user.id, data);
       response.status(200).json({ message: "Password changed successfully" });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  requestChangeEmail = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { newEmail } = changeEmailRequestSchema.parse(request.body);
+      await this.authService.requestChangeEmail(request.user.id, newEmail);
+      response.status(200).json({ message: "Email change verification sent" });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  confirmChangeEmail = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { token } = changeEmailSchema.parse(request.body);
+      await this.authService.confirmChangeEmail(token);
+      response.status(200).json({ message: "Email changed successfully" });
     } catch (error) {
       next(error);
     }

--- a/apps/api/src/middlewares/verifyToken.middleware.ts
+++ b/apps/api/src/middlewares/verifyToken.middleware.ts
@@ -1,0 +1,20 @@
+import jwt from "jsonwebtoken";
+import { Request, Response, NextFunction } from "express";
+
+export function verifyTokenMiddleware(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  const authHeader = request.headers.authorization;
+  if (!authHeader) {
+    return response.status(401).json({ message: "Missing token" });
+  }
+
+  const token = authHeader.split(" ")[1];
+
+  const decoded = jwt.verify(token, process.env.JWT_SECRET_KEY as string);
+
+  request.user = decoded;
+  next();
+}

--- a/apps/api/src/routers/auth.router.ts
+++ b/apps/api/src/routers/auth.router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authController } from "../controllers/auth.controller.js";
 import { upload } from "@/middlewares/upload.middleware.js";
+import { verifyTokenMiddleware } from "@/middlewares/verifyToken.middleware.js";
 
 const router = Router();
 router.post("/signup", authController.startRegistration);
@@ -12,7 +13,17 @@ router.post(
 router.post("/login", authController.userLogin);
 router.post("/forgot-password", authController.requestPasswordReset);
 router.post("/reset-password", authController.resetPassword);
-router.get("/profile", authController.getProfile);
-router.put("/profile", upload.single("avatarUrl"), authController.editProfile);
+router.get("/profile", verifyTokenMiddleware, authController.getProfile);
+router.put(
+  "/profile",
+  verifyTokenMiddleware,
+  upload.single("avatarUrl"),
+  authController.editProfile
+);
+router.put(
+  "/change-password",
+  verifyTokenMiddleware,
+  authController.changePassword
+);
 
 export default router;

--- a/apps/api/src/routers/auth.router.ts
+++ b/apps/api/src/routers/auth.router.ts
@@ -26,4 +26,11 @@ router.put(
   authController.changePassword
 );
 
+router.post(
+  "/change-email",
+  verifyTokenMiddleware,
+  authController.requestChangeEmail
+);
+router.post("/change-email/confirm", authController.confirmChangeEmail);
+
 export default router;

--- a/apps/api/src/services/auth.service.ts
+++ b/apps/api/src/services/auth.service.ts
@@ -6,7 +6,6 @@ import {
   UpdateUserInput,
 } from "@repo/schemas";
 import { AppError } from "@/errors/app.error.js";
-import { generateToken } from "@/utils/jwt.js";
 import { EmailService } from "./email.service.js";
 import { TokenService } from "./token.service.js";
 import bcrypt from "bcrypt";

--- a/apps/api/src/services/email.service.ts
+++ b/apps/api/src/services/email.service.ts
@@ -52,4 +52,26 @@ export class EmailService {
       text: `Click to verify your email: ${verifyLink}`,
     });
   }
+
+  async sendEmailChangeVerification(newEmail: string, token: string) {
+    const webUrl = process.env.WEB_APP_URL || "http://localhost:3000";
+    const verifyLink = `${webUrl}/verify-email-change?token=${encodeURIComponent(
+      token
+    )}`;
+
+    const template = await fs.readFile(
+      "./src/templates/emails/verify-email-change.hbs",
+      "utf-8"
+    );
+    const compiledTemplate = Handlebars.compile(template);
+    const html = compiledTemplate({ verifyLink });
+
+    await resend.emails.send({
+      from: "StayWise <onboarding@resend.dev>",
+      to: newEmail,
+      subject: "Confirm your new email",
+      html,
+      text: `Click to confirm your new email: ${verifyLink}`,
+    });
+  }
 }

--- a/apps/api/src/services/password.service.ts
+++ b/apps/api/src/services/password.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@repo/database";
+import { ResetPasswordWithTokenInput } from "@repo/schemas";
 import { AppError } from "@/errors/app.error.js";
-import { generateToken } from "@/utils/jwt.js";
 import { EmailService } from "./email.service.js";
 import { TokenService } from "./token.service.js";
 import bcrypt from "bcrypt";
@@ -25,9 +25,9 @@ export class PasswordResetService {
     return { ok: true };
   }
 
-  async resetPasswordWithToken(token: string, newPassword: string) {
+  async resetPasswordWithToken(data: ResetPasswordWithTokenInput) {
     const tokenRecord = await this.tokenService.verifyEmailToken(
-      token,
+      data.token,
       "PASSWORD_RESET"
     );
 
@@ -36,7 +36,7 @@ export class PasswordResetService {
     });
     if (!user) throw new AppError("User not found", 404);
 
-    const hashedPassword = await bcrypt.hash(newPassword, 10);
+    const hashedPassword = await bcrypt.hash(data.password, 10);
     await prisma.$transaction([
       prisma.user.update({
         where: { id: user.id },

--- a/apps/api/src/services/token.service.ts
+++ b/apps/api/src/services/token.service.ts
@@ -6,13 +6,14 @@ import { enqueueTokenExpiration } from "@/queues/token.queue.js";
 export class TokenService {
   async generateEmailToken(
     userId: string,
-    type: "EMAIL_VERIFICATION" | "PASSWORD_RESET",
-    ttlMs: number
+    type: "EMAIL_VERIFICATION" | "PASSWORD_RESET" | "EMAIL_CHANGE",
+    ttlMs: number,
+    payload: Record<string, unknown> = {}
   ) {
     const expiresAt = new Date(Date.now() + ttlMs);
     const expiresInSeconds = Math.max(1, Math.floor(ttlMs / 1000));
     const token = generateToken(
-      { id: userId, purpose: "verify" },
+      { id: userId, purpose: "verify", ...payload },
       expiresInSeconds
     );
 
@@ -39,7 +40,7 @@ export class TokenService {
 
   async verifyEmailToken(
     token: string,
-    type: "EMAIL_VERIFICATION" | "PASSWORD_RESET"
+    type: "EMAIL_VERIFICATION" | "PASSWORD_RESET" | "EMAIL_CHANGE"
   ) {
     const tokenRecord = await prisma.authToken.findFirst({
       where: { token, type, status: "ACTIVE" },

--- a/apps/api/src/services/token.service.ts
+++ b/apps/api/src/services/token.service.ts
@@ -9,8 +9,12 @@ export class TokenService {
     type: "EMAIL_VERIFICATION" | "PASSWORD_RESET",
     ttlMs: number
   ) {
-    const token = generateToken({ id: userId, purpose: "verify" }, "1h");
     const expiresAt = new Date(Date.now() + ttlMs);
+    const expiresInSeconds = Math.max(1, Math.floor(ttlMs / 1000));
+    const token = generateToken(
+      { id: userId, purpose: "verify" },
+      expiresInSeconds
+    );
 
     await prisma.$transaction(async (tx) => {
       await tx.authToken.updateMany({

--- a/apps/api/src/templates/emails/verify-email-change.hbs
+++ b/apps/api/src/templates/emails/verify-email-change.hbs
@@ -1,0 +1,41 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Confirm your new email</title>
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+      Helvetica, Arial, sans-serif; color: #111827; background: #ffffff; }
+      .container { max-width: 560px; margin: 0 auto; padding: 24px; } .btn {
+      display: inline-block; padding: 12px 20px; background: #111827; color:
+      #ffffff !important; text-decoration: none; border-radius: 6px;
+      font-weight: 600; } .muted { color: #6b7280; font-size: 14px; } .link {
+      word-break: break-all; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Confirm your new email</h1>
+      <p>You're updating the email address for your StayWise account. To confirm
+        this change, please verify your new email.</p>
+
+      <p style="margin:24px 0">
+        <a
+          class="btn"
+          href="{{verifyLink}}"
+          target="_blank"
+          rel="noopener"
+        >Confirm new email</a>
+      </p>
+
+      <p class="muted">
+        If the button doesn't work, copy and paste this link into your browser:
+      </p>
+      <p class="link">{{verifyLink}}</p>
+
+      <hr style="border:none; border-top:1px solid #e5e7eb; margin:24px 0" />
+      <p class="muted">If you didn't request this change, you can safely ignore
+        this email.</p>
+    </div>
+  </body>
+</html>

--- a/apps/api/src/utils/jwt.ts
+++ b/apps/api/src/utils/jwt.ts
@@ -1,6 +1,9 @@
 import jwt from "jsonwebtoken";
 
-export function generateToken(payload: object, expiresIn: string = "1h") {
+export function generateToken(
+  payload: object,
+  expiresIn: string | number = "1h"
+) {
   return jwt.sign(
     payload,
     process.env.JWT_SECRET_KEY as string,

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -69,6 +69,7 @@ enum BedType {
 enum TokenType {
     EMAIL_VERIFICATION
     PASSWORD_RESET
+    EMAIL_CHANGE
 }
 
 enum TokenStatus {
@@ -82,7 +83,7 @@ model AuthToken {
     id        String      @id @default(uuid())
     userId    String
     type      TokenType
-    token     String      @unique @db.VarChar(255)
+    token     String      @unique @db.Text
     expiresAt DateTime
     usedAt    DateTime?
     status    TokenStatus @default(ACTIVE)

--- a/packages/schemas/src/user.schema.ts
+++ b/packages/schemas/src/user.schema.ts
@@ -1,75 +1,63 @@
 import { z } from "zod";
 
-export const RegistrationStartSchema = z.object({
-  email: z.email("Invalid email"),
-  role: z.enum(["USER", "TENANT"]),
-});
-
-export const changePasswordPassword = z.object({
-  token: z.string().min(6, "Invalid or missing token"),
-  password: z
-    .string()
-    .min(8, "Password must be at least 8 characters")
-    .regex(/[a-z]/, "Password must contain at least one lowercase letter")
-    .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
-    .regex(/[0-9]/, "Password must contain at least one number")
-    .regex(/[^\w\s]/, "Password must contain at least one special character"),
-});
-
-export const CompleteRegistrationSchema = z.object({
-  token: z.string().min(6, "Invalid or missing token"),
+export const EmailSchema = z.email("Invalid email");
+export const CommonProfileSchema = z.object({
   firstName: z.string().min(1, "Firstname is required").max(150),
-  lastName: z.string().min(1, "Invalid last name").max(150).optional(),
-  phone: z
-    .string()
-    .regex(
-      /^\+?[1-9]\d{7,14}$/,
-      "Phone number must be in international format, e.g. +6281234567890"
-    )
-    .optional(),
-  avatarUrl: z.string().url("Invalid avatar URL").optional(),
-  password: z
-    .string()
-    .min(8, "Password must be at least 8 characters")
-    .regex(/[a-z]/, "Password must contain at least one lowercase letter")
-    .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
-    .regex(/[0-9]/, "Password must contain at least one number")
-    .regex(/[^\w\s]/, "Password must contain at least one special character"),
-});
-
-export const UpdateUserSchema = z.object({
-  email: z.email("Invalid email").optional(),
-  firstName: z.string().min(1, "Firstname is required").max(150).optional(),
   lastName: z.string().min(1, "Invalid last name").max(150).optional(),
   phone: z
     .string()
     .min(8, "Invalid phone number")
     .max(20, "Invalid phone number")
-    .regex(
-      /^\+?[1-9]\d{7,14}$/,
-      "Phone number must be in international format, e.g. +6281234567890"
-    )
     .optional(),
-  avatarUrl: z.string().url("Invalid avatar URL").optional(),
+  avatarUrl: z.url("Invalid avatar URL").optional(),
+});
+
+export const RegistrationStartSchema = z.object({
+  email: EmailSchema,
+  role: z.enum(["USER", "TENANT"]),
+});
+
+export const CompleteRegistrationSchema = CommonProfileSchema.extend({
+  token: z.string().min(6, "Invalid or missing token"),
+  password: z
+    .string()
+    .min(8, "Password must be at least 8 characters")
+    .regex(/[a-z]/, "Password must contain at least one lowercase letter")
+    .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
+    .regex(/[0-9]/, "Password must contain at least one number")
+    .regex(/[^\w\s]/, "Password must contain at least one special character"),
+});
+
+export const UpdateUserSchema = CommonProfileSchema.partial().extend({
+  email: EmailSchema.optional(),
 });
 
 export const LoginSchema = z.object({
-  email: z.email("Invalid email"),
+  email: EmailSchema,
   password: z.string(),
 });
 
 export const ForgotPasswordSchema = z.object({
-  email: z.email("Invalid email"),
+  email: EmailSchema,
 });
 
-export const ResendVerificationSchema = z.object({
-  email: z.email("Invalid email"),
+export const ResetPasswordWithTokenSchema = CompleteRegistrationSchema.pick({
+  token: true,
+  password: true,
 });
 
-export type RegistrationStartInput = z.infer<typeof RegistrationStartSchema>;
-export type SetPasswordInput = z.infer<typeof changePasswordPassword>;
-export type UpdateUserInput = z.infer<typeof UpdateUserSchema>;
+export const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1, "Current password is required"),
+  newPassword: CompleteRegistrationSchema.shape.password,
+});
+
 export type LoginInput = z.infer<typeof LoginSchema>;
+export type RegistrationStartInput = z.infer<typeof RegistrationStartSchema>;
 export type CompleteRegistrationInput = z.infer<
   typeof CompleteRegistrationSchema
 >;
+export type ResetPasswordWithTokenInput = z.infer<
+  typeof ResetPasswordWithTokenSchema
+>;
+export type UpdateUserInput = z.infer<typeof UpdateUserSchema>;
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;

--- a/packages/schemas/src/user.schema.ts
+++ b/packages/schemas/src/user.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { email, z } from "zod";
 
 export const EmailSchema = z.email("Invalid email");
 export const CommonProfileSchema = z.object({
@@ -51,6 +51,15 @@ export const changePasswordSchema = z.object({
   newPassword: CompleteRegistrationSchema.shape.password,
 });
 
+export const changeEmailSchema = z.object({
+  token: CompleteRegistrationSchema.shape.token,
+  newEmail: EmailSchema,
+});
+
+export const changeEmailRequestSchema = z.object({
+  newEmail: EmailSchema,
+});
+
 export type LoginInput = z.infer<typeof LoginSchema>;
 export type RegistrationStartInput = z.infer<typeof RegistrationStartSchema>;
 export type CompleteRegistrationInput = z.infer<
@@ -61,3 +70,5 @@ export type ResetPasswordWithTokenInput = z.infer<
 >;
 export type UpdateUserInput = z.infer<typeof UpdateUserSchema>;
 export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
+export type changeEmailInput = z.infer<typeof changeEmailSchema>;
+export type changeEmailRequestInput = z.infer<typeof changeEmailRequestSchema>;


### PR DESCRIPTION
- Adds a verified email-change flow, proper change-password support, and refactors token handling to support dynamic expirations and payloads.

- Includes schema updates, a new email template, and a Prisma schema change (AuthToken.token column type changed to Text in schema).