### PR TITLE
feat(properties): extract properties UI into components, add search-params hook, and fix API pagination

### DIFF
--- a/apps/api/src/controllers/property.controller.ts
+++ b/apps/api/src/controllers/property.controller.ts
@@ -54,14 +54,15 @@ export class PropertyController {
         sortOrder: parsed.sortOrder,
       };
 
-      const properties = await this.propertyService.getProperties(params);
+      const result = await this.propertyService.getProperties(params);
 
       response.status(200).json({
         message: "Properties fetched successfully",
-        data: properties,
+        data: result.properties,
         page,
         limit,
-        totalPage: Math.ceil(properties.length / limit),
+        total: result.total,
+        totalPage: Math.ceil(result.total / limit),
       });
     } catch (error) {
       next(error);

--- a/apps/api/src/services/property.service.ts
+++ b/apps/api/src/services/property.service.ts
@@ -108,13 +108,18 @@ export class PropertyService {
       orderBy = { Rooms: { _min: { basePrice: sortOrder || "asc" } } };
     }
 
-    return prisma.property.findMany({
+    // Get total count for pagination
+    const total = await prisma.property.count({ where });
+
+    const properties = await prisma.property.findMany({
       where,
       skip,
       take,
       orderBy,
       include: { PropertyCategory: true, Rooms: true, Pictures: true },
     });
+
+    return { properties, total };
   }
 
   async getPropertyBySlug(slug: string) {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-navigation-menu": "^1.2.14",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.85.6",

--- a/apps/web/src/app/(auth)/error/page.tsx
+++ b/apps/web/src/app/(auth)/error/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
-export default function AuthError() {
+function AuthErrorInner() {
   const searchParams = useSearchParams();
   const error = searchParams.get("error");
 
@@ -45,5 +46,19 @@ export default function AuthError() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function AuthError() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center min-h-screen">
+          Loading...
+        </div>
+      }
+    >
+      <AuthErrorInner />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 import { format } from "date-fns";
 
-export default function SearchPage() {
+function SearchPageInner() {
   const searchParams = useSearchParams();
 
   const location = searchParams.get("location") || "";
@@ -73,5 +74,15 @@ export default function SearchPage() {
         </p>
       </div>
     </div>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense
+      fallback={<div className="p-8 text-center">Loading search...</div>}
+    >
+      <SearchPageInner />
+    </Suspense>
   );
 }

--- a/apps/web/src/components/properties/FiltersBar.tsx
+++ b/apps/web/src/components/properties/FiltersBar.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Filter, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { GetPropertiesQuery } from "@repo/schemas";
+
+export interface FiltersBarProps {
+  params: GetPropertiesQuery;
+  onChange: (updates: Partial<GetPropertiesQuery>) => void;
+}
+
+export function FiltersBar({ params, onChange }: FiltersBarProps) {
+  const [nameFilter, setNameFilter] = useState(params.name || "");
+  const [categoryFilter, setCategoryFilter] = useState(
+    params.categoryName || ""
+  );
+
+  useEffect(() => {
+    setNameFilter(params.name || "");
+    setCategoryFilter(params.categoryName || "");
+  }, [params.name, params.categoryName]);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onChange({
+      name: nameFilter,
+      categoryName: categoryFilter,
+    });
+  };
+
+  const clear = () => {
+    setNameFilter("");
+    setCategoryFilter("");
+    onChange({
+      name: "",
+      categoryName: "",
+      sortBy: "",
+      sortOrder: "",
+      page: 1,
+    });
+  };
+
+  return (
+    <div className="bg-card border rounded-lg p-6 mb-8 mt-6">
+      <div className="flex items-center gap-2 mb-4">
+        <Filter className="h-5 w-5" />
+        <h2 className="text-lg font-semibold">Filters & Search</h2>
+      </div>
+
+      <form onSubmit={submit} className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Property Name</Label>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+              <Input
+                id="name"
+                type="text"
+                placeholder="Search by property name..."
+                value={nameFilter}
+                onChange={(e) => setNameFilter(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="category">Category</Label>
+            <Input
+              id="category"
+              type="text"
+              placeholder="Search by category..."
+              value={categoryFilter}
+              onChange={(e) => setCategoryFilter(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="sort">Sort By</Label>
+            <Select
+              value={
+                params.sortBy && params.sortOrder
+                  ? `${params.sortBy}-${params.sortOrder}`
+                  : ""
+              }
+              onValueChange={(value) => {
+                const [sortBy, sortOrder] = value.split("-") as [
+                  "name" | "price",
+                  "asc" | "desc"
+                ];
+                onChange({ sortBy, sortOrder });
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Sort by..." />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="name-asc">Name (A-Z)</SelectItem>
+                <SelectItem value="name-desc">Name (Z-A)</SelectItem>
+                <SelectItem value="price-asc">Price (Low to High)</SelectItem>
+                <SelectItem value="price-desc">Price (High to Low)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <Button type="submit">
+            <Search className="h-4 w-4 mr-2" />
+            Apply Filters
+          </Button>
+          <Button type="button" variant="outline" onClick={clear}>
+            Clear All
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/properties/Pagination.tsx
+++ b/apps/web/src/components/properties/Pagination.tsx
@@ -1,0 +1,63 @@
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { GetPropertiesQuery } from "@repo/schemas";
+
+interface PaginationProps {
+  totalPages: number;
+  params: GetPropertiesQuery;
+  onPage: (page: number) => void;
+}
+
+export function Pagination({ totalPages, params, onPage }: PaginationProps) {
+  if (totalPages <= 1) return null;
+  const currentPage = params.page || 1;
+
+  return (
+    <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+      <div className="text-sm text-muted-foreground">
+        Page {currentPage} of {totalPages}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPage(currentPage - 1)}
+          disabled={currentPage <= 1}
+        >
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Previous
+        </Button>
+        <div className="flex items-center gap-1">
+          {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+            let pageNumber: number;
+            if (totalPages <= 5) pageNumber = i + 1;
+            else if (currentPage <= 3) pageNumber = i + 1;
+            else if (currentPage >= totalPages - 2)
+              pageNumber = totalPages - 4 + i;
+            else pageNumber = currentPage - 2 + i;
+            return (
+              <Button
+                key={pageNumber}
+                variant={pageNumber === currentPage ? "default" : "outline"}
+                size="sm"
+                className="w-10 h-10"
+                onClick={() => onPage(pageNumber)}
+              >
+                {pageNumber}
+              </Button>
+            );
+          })}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPage(currentPage + 1)}
+          disabled={currentPage >= totalPages}
+        >
+          Next
+          <ChevronRight className="h-4 w-4 ml-1" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/properties/PropertiesGrid.tsx
+++ b/apps/web/src/components/properties/PropertiesGrid.tsx
@@ -1,0 +1,16 @@
+import type { Property } from "@/types/property";
+import { PropertyCard } from "./PropertyCard";
+
+interface PropertiesGridProps {
+  properties: Property[];
+}
+
+export function PropertiesGrid({ properties }: PropertiesGridProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+      {properties.map((property) => (
+        <PropertyCard key={property.id} property={property} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/properties/PropertiesSummary.tsx
+++ b/apps/web/src/components/properties/PropertiesSummary.tsx
@@ -1,0 +1,74 @@
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { GetPropertiesQuery } from "@repo/schemas";
+
+interface PropertiesSummaryProps {
+  total: number;
+  params: GetPropertiesQuery;
+  isLoading: boolean;
+  onChange: (updates: Partial<GetPropertiesQuery>) => void;
+  formatLocation: (l: string) => string;
+  toTitleCase: (s: string) => string;
+}
+
+export function PropertiesSummary({
+  total,
+  params,
+  isLoading,
+  onChange,
+  formatLocation,
+  toTitleCase,
+}: PropertiesSummaryProps) {
+  const summary = (() => {
+    if (isLoading) return "Loading...";
+    let text = "";
+    if (params.name || params.categoryName || params.location) {
+      const filters = [] as string[];
+      if (params.name) filters.push(`for "${params.name}"`);
+      if (params.categoryName)
+        filters.push(`in category "${params.categoryName}"`);
+      if (params.location)
+        filters.push(`in ${formatLocation(params.location)}`);
+      if (total === 0) text = `No Properties ${filters.join(" ")}`;
+      else if (total === 1) text = `1 Property ${filters.join(" ")}`;
+      else text = `${total} Properties ${filters.join(" ")}`;
+    } else {
+      text = `All Properties (${total})`;
+    }
+    return toTitleCase(text.trim());
+  })();
+
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6">
+      <div className="mb-4 sm:mb-0">
+        <h1 className="text-2xl font-bold text-foreground">{summary}</h1>
+      </div>
+      <div className="flex items-center gap-2">
+        <Label htmlFor="pageSize" className="text-sm">
+          Show:
+        </Label>
+        <Select
+          value={String(params.limit || 12)}
+          onValueChange={(value) => onChange({ limit: Number(value), page: 1 })}
+        >
+          <SelectTrigger className="w-20">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="6">6</SelectItem>
+            <SelectItem value="12">12</SelectItem>
+            <SelectItem value="24">24</SelectItem>
+            <SelectItem value="48">48</SelectItem>
+          </SelectContent>
+        </Select>
+        <span className="text-sm text-muted-foreground">per page</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/properties/PropertyCard.tsx
+++ b/apps/web/src/components/properties/PropertyCard.tsx
@@ -1,0 +1,85 @@
+import Image from "next/image";
+import Link from "next/link";
+import { MapPin, Users, Bed, Bath, Star } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { Property } from "@/types/property";
+
+interface PropertyCardProps {
+  property: Property;
+}
+
+export function PropertyCard({ property }: PropertyCardProps) {
+  const totalBedrooms = property.Rooms?.length || 1;
+  const totalBathrooms = property.Rooms?.length || 1;
+  const basePrice = property.Rooms?.[0]?.basePrice || 120;
+
+  return (
+    <Card
+      key={property.id}
+      className="overflow-hidden hover:shadow-lg transition-shadow"
+    >
+      <div className="relative aspect-[16/9]">
+        <Image
+          src={property.Pictures[0]?.imageUrl}
+          alt={property.name}
+          fill
+          className="object-cover"
+        />
+        <Badge className="absolute top-3 left-3">Available</Badge>
+        {property.PropertyCategory && (
+          <Badge variant="secondary" className="absolute top-3 right-3">
+            {property.PropertyCategory.name}
+          </Badge>
+        )}
+      </div>
+      <CardContent className="p-4">
+        <CardHeader className="p-0 mb-3">
+          <CardTitle className="text-lg">{property.name}</CardTitle>
+          <div className="flex items-center gap-1 text-muted-foreground text-sm">
+            <MapPin className="h-4 w-4" />
+            <span>{property.city}</span>
+          </div>
+        </CardHeader>
+
+        <div className="flex items-center gap-4 text-sm text-muted-foreground mb-4">
+          <div className="flex items-center gap-1">
+            <Users className="h-4 w-4" />
+            <span>{property.maxGuests || 4} Guests</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Bed className="h-4 w-4" />
+            <span>{totalBedrooms} Bedrooms</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Bath className="h-4 w-4" />
+            <span>{totalBathrooms} Bathrooms</span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 mb-4">
+          <div className="flex items-center gap-1">
+            <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+            <span className="font-medium">4.8</span>
+          </div>
+          <span className="text-muted-foreground">(139 reviews)</span>
+        </div>
+
+        <p className="text-muted-foreground text-sm mb-4 line-clamp-2">
+          {property.description}
+        </p>
+
+        <div className="flex items-center justify-between">
+          <div>
+            <span className="text-xl font-bold">${basePrice}</span>
+            <span className="text-muted-foreground">/night</span>
+          </div>
+          <Link href={`/properties/${property.slug}`}>
+            <Button>View Details</Button>
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/apps/web/src/hooks/usePropertySearchParams.ts
+++ b/apps/web/src/hooks/usePropertySearchParams.ts
@@ -1,0 +1,51 @@
+"use client";
+import { useMemo, useCallback } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import type { GetPropertiesQuery } from "@repo/schemas";
+
+export function usePropertySearchParams(): [
+  GetPropertiesQuery,
+  (u: Partial<GetPropertiesQuery>) => void
+] {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchString = searchParams.toString();
+
+  const params = useMemo<GetPropertiesQuery>(() => {
+    const sp = new URLSearchParams(searchString);
+    const toInt = (v: string | null) =>
+      v == null || v === "" ? undefined : Number.parseInt(v, 10);
+    return {
+      page: toInt(sp.get("page")) || 1,
+      limit: toInt(sp.get("limit")) || 12,
+      location: sp.get("location") ?? undefined,
+      checkIn: sp.get("checkIn") ?? undefined,
+      checkOut: sp.get("checkOut") ?? undefined,
+      adults: toInt(sp.get("adults")),
+      children: toInt(sp.get("children")),
+      guest: toInt(sp.get("guest")),
+      pets: toInt(sp.get("pets")),
+      name: sp.get("name") ?? undefined,
+      categoryName: sp.get("categoryName") ?? undefined,
+      sortBy: (sp.get("sortBy") as "name" | "price") ?? undefined,
+      sortOrder: (sp.get("sortOrder") as "asc" | "desc") ?? undefined,
+    };
+  }, [searchString]);
+
+  const update = useCallback(
+    (updates: Partial<GetPropertiesQuery>) => {
+      const newParams = new URLSearchParams(searchParams);
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value === undefined || value === null || value === "")
+          newParams.delete(key);
+        else newParams.set(key, String(value));
+      });
+      if (!updates.hasOwnProperty("page")) newParams.set("page", "1");
+      router.replace(`${pathname}?${newParams.toString()}`);
+    },
+    [searchParams, router, pathname]
+  );
+
+  return [params, update];
+}

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -3,6 +3,7 @@ export type ApiListResponse<T> = {
   data: T[];
   page: number;
   limit: number;
+  total: number;
   totalPage: number;
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
                 "@radix-ui/react-navigation-menu": "^1.2.14",
                 "@radix-ui/react-popover": "^1.1.15",
                 "@radix-ui/react-scroll-area": "^1.2.10",
+                "@radix-ui/react-select": "^2.2.6",
                 "@radix-ui/react-separator": "^1.1.7",
                 "@radix-ui/react-slot": "^1.2.3",
                 "@tanstack/react-query": "^5.85.6",
@@ -2426,6 +2427,49 @@
                 "@radix-ui/react-primitive": "2.1.3",
                 "@radix-ui/react-use-callback-ref": "1.1.1",
                 "@radix-ui/react-use-layout-effect": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-select": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+            "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/number": "1.1.1",
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-collection": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-dismissable-layer": "1.1.11",
+                "@radix-ui/react-focus-guards": "1.1.3",
+                "@radix-ui/react-focus-scope": "1.1.7",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-popper": "1.2.8",
+                "@radix-ui/react-portal": "1.1.9",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-slot": "1.2.3",
+                "@radix-ui/react-use-callback-ref": "1.1.1",
+                "@radix-ui/react-use-controllable-state": "1.2.2",
+                "@radix-ui/react-use-layout-effect": "1.1.1",
+                "@radix-ui/react-use-previous": "1.1.1",
+                "@radix-ui/react-visually-hidden": "1.2.3",
+                "aria-hidden": "^1.2.4",
+                "react-remove-scroll": "^2.6.3"
             },
             "peerDependencies": {
                 "@types/react": "*",


### PR DESCRIPTION
Refactor properties listing into small components, add a hook to manage URL search params, and fix API pagination to return total count.

Quick test:

- Build web: cd apps/web && npm run build (should succeed).

- Open /properties, verify filters work and pagination shows correct totals.

- Call GET /properties and confirm response includes [total].