### PR TITLE
feat(tenant-dashboard): tenant properties page + tenant property APIs

### DIFF
--- a/apps/api/src/controllers/property.controller.ts
+++ b/apps/api/src/controllers/property.controller.ts
@@ -84,6 +84,55 @@ export class PropertyController {
       next(error);
     }
   };
+
+  getPropertiesByTenant = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const tenantId = request.params.tenantId;
+
+      if (request.user?.id !== tenantId) {
+        return response.status(403).json({
+          message: "Access denied: You can only view your own properties",
+        });
+      }
+
+      const properties = await this.propertyService.getPropertiesByTenant(
+        tenantId
+      );
+      response.status(200).json({
+        message: "Tenant properties fetched successfully",
+        data: properties,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  deleteProperty = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const propertyId = request.params.propertyId;
+      const tenantId = request.user?.id;
+
+      if (!tenantId) {
+        return response.status(401).json({ message: "Unauthorized" });
+      }
+
+      const result = await this.propertyService.deleteProperty(
+        propertyId,
+        tenantId
+      );
+      response.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  };
 }
 
 export const propertyController = new PropertyController();

--- a/apps/api/src/routers/property.route.ts
+++ b/apps/api/src/routers/property.route.ts
@@ -1,10 +1,24 @@
 import { Router } from "express";
 import { propertyController } from "../controllers/property.controller.js";
+import { verifyTokenMiddleware } from "../middlewares/verifyToken.middleware.js";
+import { verifyRoleMiddleware } from "../middlewares/verifyRole.middleware.js";
 
 const router = Router();
 
 router.post("/", propertyController.createProperty);
 router.get("/", propertyController.getProperties);
+router.get(
+  "/tenant/:tenantId",
+  verifyTokenMiddleware,
+  verifyRoleMiddleware,
+  propertyController.getPropertiesByTenant
+);
+router.delete(
+  "/:propertyId",
+  verifyTokenMiddleware,
+  verifyRoleMiddleware,
+  propertyController.deleteProperty
+);
 router.get("/:slug", propertyController.getProperty);
 
 export default router;

--- a/apps/web/src/app/dashboard/tenant/layout.tsx
+++ b/apps/web/src/app/dashboard/tenant/layout.tsx
@@ -1,68 +1,44 @@
 import type { Metadata } from "next";
-import { Figtree, Geist_Mono } from "next/font/google";
-import "../../globals.css";
 import { TenantSidebar } from "@/components/tenant/tenant-sidebar";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { Menu } from "lucide-react";
-import { Toaster } from "@/components/ui/sonner";
 import { DynamicHeader } from "../../../components/tenant/dynamic-header";
 
-const figtree = Figtree({
-  variable: "--font-figtree",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
 export const metadata: Metadata = {
-  title: "StayWise Tenant",
-  description: "Your one-stop solution for finding the perfect rental property",
+  title: "StayWise Tenant Dashboard",
+  description: "Manage your property listings and bookings",
 };
 
-interface RootLayoutProps {
+interface TenantLayoutProps {
   children: React.ReactNode;
 }
 
-export default function RootLayout({ children }: RootLayoutProps) {
+export default function TenantLayout({ children }: TenantLayoutProps) {
   return (
-    <html lang="en">
-      <body className={`${figtree.variable} ${geistMono.variable} antialiased`}>
-        <Toaster />
-        <main className="min-h-[calc(100vh-12rem)]">
-          <div className="flex min-h-dvh">
-            <div className="hidden md:block">
-              <TenantSidebar />
-            </div>
-            <main className="flex-1">
-              <header className="h-14 border-b flex items-center px-4 justify-between gap-2">
-                <div className="flex items-center gap-2">
-                  <Sheet>
-                    <SheetTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="icon"
-                        className="md:hidden"
-                      >
-                        <Menu className="size-4" />
-                        <span className="sr-only">Open Menu</span>
-                      </Button>
-                    </SheetTrigger>
-                    <SheetContent side="left" className="p-0">
-                      <TenantSidebar />
-                    </SheetContent>
-                  </Sheet>
-                  <DynamicHeader />
-                </div>
-              </header>
-              <section className="flex-1 p-4">{children}</section>
-            </main>
+    <div className="flex min-h-[calc(100vh-12rem)]">
+      <div className="hidden md:block">
+        <TenantSidebar />
+      </div>
+      <main className="flex-1">
+        <header className="h-14 border-b flex items-center px-4 justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Sheet>
+              <SheetTrigger asChild>
+                <Button variant="outline" size="icon" className="md:hidden">
+                  <Menu className="size-4" />
+                  <span className="sr-only">Open Menu</span>
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="left" className="p-0">
+                <TenantSidebar />
+              </SheetContent>
+            </Sheet>
+            <DynamicHeader />
           </div>
-        </main>
-      </body>
-    </html>
+        </header>
+        <section className="flex-1 p-4">{children}</section>
+      </main>
+    </div>
   );
 }

--- a/apps/web/src/app/dashboard/tenant/properties/page.tsx
+++ b/apps/web/src/app/dashboard/tenant/properties/page.tsx
@@ -1,3 +1,41 @@
-export default function ListProperty() {
-  return <div></div>;
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { TenantPropertiesList } from "@/components/tenant/tenant-properties-list";
+import { PropertyStats } from "@/components/tenant/property-stats";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+import Link from "next/link";
+
+export default async function TenantPropertiesPage() {
+  const session = await auth();
+
+  if (!session?.user || session.user.role !== "TENANT") {
+    redirect("/auth/signin");
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header Section */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold tracking-tight">My Properties</h1>
+          <p className="text-muted-foreground">
+            Manage and view all your property listings
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/dashboard/tenant/properties/new">
+            <Plus className="h-4 w-4 mr-2" />
+            Add New Property
+          </Link>
+        </Button>
+      </div>
+
+      {/* Stats Cards */}
+      <PropertyStats tenantId={session.user.id} />
+
+      {/* Properties List */}
+      <TenantPropertiesList tenantId={session.user.id} />
+    </div>
+  );
 }

--- a/apps/web/src/components/tenant/property-stats.tsx
+++ b/apps/web/src/components/tenant/property-stats.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Building2, Bed, Users, Calendar } from "lucide-react";
+import { useTenantProperties } from "@/hooks/useTenantProperties";
+
+interface PropertyStatsProps {
+  tenantId: string;
+}
+
+interface PropertyStats {
+  totalProperties: number;
+  totalRooms: number;
+  totalCapacity: number;
+  totalBookings: number;
+}
+
+export function PropertyStats({ tenantId }: PropertyStatsProps) {
+  const { properties, loading } = useTenantProperties(tenantId);
+  const [stats, setStats] = useState<PropertyStats>({
+    totalProperties: 0,
+    totalRooms: 0,
+    totalCapacity: 0,
+    totalBookings: 0,
+  });
+
+  useEffect(() => {
+    if (properties.length > 0) {
+      const calculatedStats = properties.reduce(
+        (acc: PropertyStats, property) => {
+          acc.totalProperties += 1;
+          acc.totalRooms += property.Rooms?.length || 0;
+          acc.totalCapacity += property.maxGuests || 0;
+
+          const bookings = property._count?.Bookings ?? 0;
+          acc.totalBookings += bookings;
+
+          return acc;
+        },
+        {
+          totalProperties: 0,
+          totalRooms: 0,
+          totalCapacity: 0,
+          totalBookings: 0,
+        }
+      );
+
+      setStats(calculatedStats);
+    } else {
+      setStats({
+        totalProperties: 0,
+        totalRooms: 0,
+        totalCapacity: 0,
+        totalBookings: 0,
+      });
+    }
+  }, [properties]);
+
+  const statsCards = [
+    {
+      title: "Total Properties",
+      value: stats.totalProperties,
+      description: "Active listings",
+      icon: Building2,
+    },
+    {
+      title: "Total Rooms",
+      value: stats.totalRooms,
+      description: "Across all properties",
+      icon: Bed,
+    },
+    {
+      title: "Total Capacity",
+      value: stats.totalCapacity,
+      description: "Maximum guests",
+      icon: Users,
+    },
+    {
+      title: "Total Bookings",
+      value: stats.totalBookings,
+      description: "All bookings across properties",
+      icon: Calendar,
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      {statsCards.map((card, index) => (
+        <Card key={index}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">{card.title}</CardTitle>
+            <card.icon className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {loading ? "..." : card.value}
+            </div>
+            <p className="text-xs text-muted-foreground">{card.description}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/tenant/tenant-properties-list.tsx
+++ b/apps/web/src/components/tenant/tenant-properties-list.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { Card, CardContent, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  MapPin,
+  Users,
+  Bed,
+  Eye,
+  Edit,
+  Trash2,
+  Calendar,
+  DollarSign,
+  Building2,
+  ImageIcon,
+} from "lucide-react";
+import { useTenantProperties } from "@/hooks/useTenantProperties";
+
+interface TenantPropertiesListProps {
+  tenantId: string;
+}
+
+export function TenantPropertiesList({ tenantId }: TenantPropertiesListProps) {
+  const { properties, loading, error, deleteProperty, refetch } =
+    useTenantProperties(tenantId);
+
+  const handleDeleteProperty = async (propertyId: string) => {
+    if (!confirm("Are you sure you want to delete this property?")) {
+      return;
+    }
+    await deleteProperty(propertyId);
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        {[...Array(3)].map((_, i) => (
+          <Card key={i} className="animate-pulse">
+            <CardContent className="p-6">
+              <div className="flex gap-4">
+                <div className="w-32 h-24 bg-gray-200 rounded-lg"></div>
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 bg-gray-200 rounded w-1/3"></div>
+                  <div className="h-3 bg-gray-200 rounded w-1/2"></div>
+                  <div className="h-3 bg-gray-200 rounded w-1/4"></div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="p-6 text-center">
+          <div className="text-red-500 mb-2">{error}</div>
+          <Button onClick={refetch} variant="outline">
+            Try Again
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (properties.length === 0) {
+    return (
+      <Card>
+        <CardContent className="p-12 text-center">
+          <Building2 className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+          <h3 className="text-lg font-semibold mb-2">No Properties Yet</h3>
+          <p className="text-muted-foreground mb-4">
+            You haven&apos;t added any properties to your portfolio yet.
+          </p>
+          <Button asChild>
+            <Link href="/dashboard/tenant/properties/new">
+              Add Your First Property
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {properties.map((property) => {
+        const totalRooms = property.Rooms?.length || 0;
+        const minPrice =
+          property.Rooms?.length > 0
+            ? Math.min(...property.Rooms.map((room) => room.basePrice))
+            : 0;
+        const maxPrice =
+          property.Rooms?.length > 0
+            ? Math.max(...property.Rooms.map((room) => room.basePrice))
+            : 0;
+        const priceDisplay =
+          minPrice === maxPrice
+            ? `$${minPrice}`
+            : `$${minPrice} - $${maxPrice}`;
+
+        return (
+          <Card
+            key={property.id}
+            className="overflow-hidden hover:shadow-md transition-shadow"
+          >
+            <CardContent className="p-0">
+              <div className="flex flex-col sm:flex-row">
+                <div className="relative w-full sm:w-48 h-48 sm:h-auto">
+                  {property.Pictures?.[0]?.imageUrl ? (
+                    <Image
+                      src={property.Pictures[0].imageUrl}
+                      alt={property.name}
+                      fill
+                      className="object-cover"
+                    />
+                  ) : (
+                    <div className="w-full h-full bg-gray-100 flex items-center justify-center">
+                      <ImageIcon className="h-8 w-8 text-gray-400" />
+                    </div>
+                  )}
+
+                  {(property.PropertyCategory || property.CustomCategory) && (
+                    <Badge
+                      variant="secondary"
+                      className="absolute top-2 left-2"
+                    >
+                      {property.PropertyCategory?.name ||
+                        property.CustomCategory?.name}
+                    </Badge>
+                  )}
+                </div>
+
+                <div className="flex-1 p-6">
+                  <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
+                    <div className="space-y-2 flex-1">
+                      <CardTitle className="text-xl">{property.name}</CardTitle>
+
+                      <div className="flex items-center gap-1 text-muted-foreground text-sm">
+                        <MapPin className="h-4 w-4" />
+                        <span>
+                          {property.city}, {property.country}
+                        </span>
+                      </div>
+
+                      <p className="text-sm text-muted-foreground line-clamp-2">
+                        {property.description}
+                      </p>
+
+                      <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                        <div className="flex items-center gap-1">
+                          <Users className="h-4 w-4" />
+                          <span>{property.maxGuests} Guests</span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <Bed className="h-4 w-4" />
+                          <span>
+                            {totalRooms} {totalRooms === 1 ? "Room" : "Rooms"}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <DollarSign className="h-4 w-4" />
+                          <span>{priceDisplay}/night</span>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="flex flex-row sm:flex-col gap-2">
+                      <Button size="sm" variant="outline" asChild>
+                        <Link href={`/properties/${property.slug}`}>
+                          <Eye className="h-4 w-4 mr-1" />
+                          View
+                        </Link>
+                      </Button>
+
+                      <Button size="sm" variant="outline" asChild>
+                        <Link
+                          href={`/dashboard/tenant/properties/${property.id}/edit`}
+                        >
+                          <Edit className="h-4 w-4 mr-1" />
+                          Edit
+                        </Link>
+                      </Button>
+
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleDeleteProperty(property.id)}
+                        className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                      >
+                        <Trash2 className="h-4 w-4 mr-1" />
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 pt-4 border-t flex flex-wrap gap-4 text-xs text-muted-foreground">
+                    <div className="flex items-center gap-1">
+                      <Calendar className="h-3 w-3" />
+                      <span>Created: {new Date().toLocaleDateString()}</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Building2 className="h-3 w-3" />
+                      <span>Property ID: {property.id.slice(0, 8)}...</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useTenantProperties.ts
+++ b/apps/web/src/hooks/useTenantProperties.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import axios from "axios";
+import { toast } from "sonner";
+
+interface PropertyPicture {
+  imageUrl: string;
+  note?: string;
+}
+
+interface PropertyRoom {
+  name?: string;
+  basePrice: number;
+  beds?: number;
+}
+
+interface PropertyCategory {
+  name: string;
+}
+
+interface TenantProperty {
+  id: string;
+  name: string;
+  slug: string;
+  description: string;
+  city: string;
+  country: string;
+  maxGuests: number;
+  createdAt: string;
+  Pictures: PropertyPicture[];
+  Rooms: PropertyRoom[];
+  PropertyCategory?: PropertyCategory;
+  CustomCategory?: PropertyCategory;
+  _count?: {
+    Bookings?: number;
+    Reviews?: number;
+  };
+}
+
+const createApiInstance = (accessToken?: string) => {
+  const api = axios.create({
+    baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1",
+  });
+
+  if (accessToken) {
+    api.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+  }
+
+  return api;
+};
+
+export function useTenantProperties(tenantId: string) {
+  const { data: session } = useSession();
+  const [properties, setProperties] = useState<TenantProperty[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProperties = useCallback(async () => {
+    if (!session?.user?.accessToken) {
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      const api = createApiInstance(session.user.accessToken);
+      const response = await api.get(`/properties/tenant/${tenantId}`);
+      setProperties(response.data.data || []);
+    } catch (err) {
+      console.error("Error fetching properties:", err);
+      setError("Failed to load properties");
+      toast.error("Failed to load properties");
+    } finally {
+      setLoading(false);
+    }
+  }, [tenantId, session?.user?.accessToken]);
+
+  const deleteProperty = useCallback(
+    async (propertyId: string) => {
+      if (!session?.user?.accessToken) return;
+
+      try {
+        const api = createApiInstance(session.user.accessToken);
+        await api.delete(`/properties/${propertyId}`);
+        setProperties((props) => props.filter((p) => p.id !== propertyId));
+        toast.success("Property deleted successfully");
+      } catch (err) {
+        console.error("Error deleting property:", err);
+        toast.error("Failed to delete property");
+      }
+    },
+    [session?.user?.accessToken]
+  );
+
+  useEffect(() => {
+    if (session?.user?.accessToken) {
+      fetchProperties();
+    }
+  }, [fetchProperties, session?.user?.accessToken]);
+
+  return {
+    properties,
+    loading,
+    error,
+    refetch: fetchProperties,
+    deleteProperty,
+  };
+}


### PR DESCRIPTION
Add tenant dashboard properties UI (list, stats, CRUD actions) and backend endpoints to list and delete properties for a tenant. Also refactor client axios to avoid server-only imports and remove session token usage from the tenant properties hook to prevent bundling server modules into the client.
