### PR TITLE
feat(tenant): guest-range from rooms, centralize schema types, branded loaders

### DIFF
--- a/apps/web/src/components/tenant/tenant-properties-list.tsx
+++ b/apps/web/src/components/tenant/tenant-properties-list.tsx
@@ -18,6 +18,8 @@ import {
   ImageIcon,
 } from "lucide-react";
 import { useTenantProperties } from "@/hooks/useTenantProperties";
+import type { RoomResponse } from "@repo/schemas";
+import { Ellipsis } from "@/components/ui/ellipsis";
 
 interface TenantPropertiesListProps {
   tenantId: string;
@@ -36,21 +38,8 @@ export function TenantPropertiesList({ tenantId }: TenantPropertiesListProps) {
 
   if (loading) {
     return (
-      <div className="space-y-4">
-        {[...Array(3)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardContent className="p-6">
-              <div className="flex gap-4">
-                <div className="w-32 h-24 bg-gray-200 rounded-lg"></div>
-                <div className="flex-1 space-y-2">
-                  <div className="h-4 bg-gray-200 rounded w-1/3"></div>
-                  <div className="h-3 bg-gray-200 rounded w-1/2"></div>
-                  <div className="h-3 bg-gray-200 rounded w-1/4"></div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
+      <div className="flex items-center justify-center py-12">
+        <Ellipsis className="text-muted-foreground" />
       </div>
     );
   }
@@ -93,16 +82,40 @@ export function TenantPropertiesList({ tenantId }: TenantPropertiesListProps) {
         const totalRooms = property.Rooms?.length || 0;
         const minPrice =
           property.Rooms?.length > 0
-            ? Math.min(...property.Rooms.map((room) => room.basePrice))
+            ? Math.min(
+                ...property.Rooms.map((room: RoomResponse) => room.basePrice)
+              )
             : 0;
         const maxPrice =
           property.Rooms?.length > 0
-            ? Math.max(...property.Rooms.map((room) => room.basePrice))
+            ? Math.max(
+                ...property.Rooms.map((room: RoomResponse) => room.basePrice)
+              )
             : 0;
         const priceDisplay =
           minPrice === maxPrice
             ? `$${minPrice}`
             : `$${minPrice} - $${maxPrice}`;
+        const minGuests =
+          property.Rooms?.length > 0
+            ? Math.min(
+                ...property.Rooms.map(
+                  (room: RoomResponse) => room.capacity ?? 1
+                )
+              )
+            : property.maxGuests ?? 0;
+        const maxGuests =
+          property.Rooms?.length > 0
+            ? Math.max(
+                ...property.Rooms.map(
+                  (room: RoomResponse) => room.capacity ?? 1
+                )
+              )
+            : property.maxGuests ?? 0;
+        const guestDisplay =
+          minGuests === maxGuests
+            ? `${minGuests}`
+            : `${minGuests} - ${maxGuests}`;
 
         return (
           <Card
@@ -155,7 +168,7 @@ export function TenantPropertiesList({ tenantId }: TenantPropertiesListProps) {
                       <div className="flex items-center gap-4 text-sm text-muted-foreground">
                         <div className="flex items-center gap-1">
                           <Users className="h-4 w-4" />
-                          <span>{property.maxGuests} Guests</span>
+                          <span>{guestDisplay} Guests</span>
                         </div>
                         <div className="flex items-center gap-1">
                           <Bed className="h-4 w-4" />

--- a/apps/web/src/components/ui/ellipsis.tsx
+++ b/apps/web/src/components/ui/ellipsis.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+
+interface EllipsisProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: number;
+  color?: string;
+}
+
+export function Ellipsis({
+  size = 6,
+  color = "var(--color-primary)",
+  className,
+  ...props
+}: EllipsisProps) {
+  const dotSize = size;
+  return (
+    <div className={className} {...props} aria-hidden>
+      <style jsx>{`
+        .ellipsis {
+          display: inline-flex;
+          gap: ${dotSize / 2}px;
+          align-items: center;
+        }
+        .ellipsis div {
+          width: ${dotSize}px;
+          height: ${dotSize}px;
+          background: ${color};
+          border-radius: 9999px;
+          opacity: 0.3;
+          transform: translateY(0);
+          animation: ellipsis 1s infinite;
+        }
+        .ellipsis div:nth-child(2) {
+          animation-delay: 0.16s;
+        }
+        .ellipsis div:nth-child(3) {
+          animation-delay: 0.32s;
+        }
+        @keyframes ellipsis {
+          0% {
+            opacity: 0.3;
+            transform: translateY(0);
+          }
+          50% {
+            opacity: 1;
+            transform: translateY(-6px);
+          }
+          100% {
+            opacity: 0.3;
+            transform: translateY(0);
+          }
+        }
+      `}</style>
+      <div className="ellipsis">
+        <div />
+        <div />
+        <div />
+      </div>
+    </div>
+  );
+}
+
+export default Ellipsis;

--- a/apps/web/src/hooks/useTenantProperties.ts
+++ b/apps/web/src/hooks/useTenantProperties.ts
@@ -4,40 +4,13 @@ import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import axios from "axios";
 import { toast } from "sonner";
+import type { PropertyResponse, RoomResponse } from "@repo/schemas";
 
-interface PropertyPicture {
-  imageUrl: string;
-  note?: string;
-}
-
-interface PropertyRoom {
-  name?: string;
-  basePrice: number;
-  beds?: number;
-}
-
-interface PropertyCategory {
-  name: string;
-}
-
-interface TenantProperty {
-  id: string;
-  name: string;
-  slug: string;
-  description: string;
-  city: string;
-  country: string;
-  maxGuests: number;
-  createdAt: string;
-  Pictures: PropertyPicture[];
-  Rooms: PropertyRoom[];
-  PropertyCategory?: PropertyCategory;
-  CustomCategory?: PropertyCategory;
-  _count?: {
-    Bookings?: number;
-    Reviews?: number;
-  };
-}
+type TenantProperty = PropertyResponse & {
+  Pictures?: { imageUrl: string; note?: string }[];
+  Rooms?: RoomResponse[];
+  _count?: { Bookings?: number; Reviews?: number };
+};
 
 const createApiInstance = (accessToken?: string) => {
   const api = axios.create({


### PR DESCRIPTION
- Compute guest capacity range per property from room capacities and display it in tenant properties list.
- Replace local PropertyRoom types with shared types from @repo/schemas and update hook typings.
- Add a branded ellipsis loader (and reusable Spinner) in UI and swap tenant list loading state to use it.
- Minor typing fixes (annotated map/reduce callbacks to remove implicit any).