### PR TITLE
feat(auth): add session expiration to JWT and add dashboard auth middleware

### DIFF
--- a/apps/api/src/services/auth.service.ts
+++ b/apps/api/src/services/auth.service.ts
@@ -83,6 +83,7 @@ export class AuthService {
       name: user.firstName,
       email: user.email,
       role: user.role,
+      expiresIn: "7d",
     });
 
     return { accessToken: token };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@auth/prisma-adapter": "^2.10.0",
     "@hookform/resolvers": "^5.2.1",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/apps/web/src/app/dashboard/tenant/properties/page.tsx
+++ b/apps/web/src/app/dashboard/tenant/properties/page.tsx
@@ -1,5 +1,4 @@
 import { auth } from "@/auth";
-import { redirect } from "next/navigation";
 import { TenantPropertiesList } from "@/components/tenant/tenant-properties-list";
 import { PropertyStats } from "@/components/tenant/property-stats";
 import { Button } from "@/components/ui/button";
@@ -8,10 +7,6 @@ import Link from "next/link";
 
 export default async function TenantPropertiesPage() {
   const session = await auth();
-
-  if (!session?.user || session.user.role !== "TENANT") {
-    redirect("/auth/signin");
-  }
 
   return (
     <div className="space-y-6">
@@ -30,9 +25,9 @@ export default async function TenantPropertiesPage() {
         </Button>
       </div>
 
-      <PropertyStats tenantId={session.user.id} />
+      <PropertyStats tenantId={session!.user.id} />
 
-      <TenantPropertiesList tenantId={session.user.id} />
+      <TenantPropertiesList tenantId={session!.user.id} />
     </div>
   );
 }

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -1,8 +1,8 @@
 import nextAuth, { DefaultSession } from "next-auth";
-import { PrismaAdapter } from "@auth/prisma-adapter";
+// import { PrismaAdapter } from "@auth/prisma-adapter";
 import { jwtDecode } from "jwt-decode";
 import { api } from "@/lib/axios";
-import { prisma } from "@repo/database";
+// import { prisma } from "@repo/database";
 import CredentialsProvider from "next-auth/providers/credentials";
 import GoogleProvider from "next-auth/providers/google";
 
@@ -31,7 +31,8 @@ declare module "next-auth" {
 }
 
 export const { handlers, signIn, signOut, auth } = nextAuth({
-  adapter: PrismaAdapter(prisma),
+  // Comment out PrismaAdapter since we're using JWT sessions
+  // adapter: PrismaAdapter(prisma),
   providers: [
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID!,
@@ -69,7 +70,7 @@ export const { handlers, signIn, signOut, auth } = nextAuth({
         try {
           const resp = await api.get(`/auth/user`, {
             params: { email: token.email },
-          }); 
+          });
           const dbUser = resp?.data?.data;
           if (dbUser) {
             token.id = dbUser.id;

--- a/apps/web/src/components/tenant/dynamic-header.tsx
+++ b/apps/web/src/components/tenant/dynamic-header.tsx
@@ -7,7 +7,6 @@ const routeTitleMap: Record<string, string> = {
   "/dashboard/tenant/properties": "List Property",
   "/dashboard/tenant/properties/add": "Add Property",
   "/dashboard/tenant/properties/categories": "Property Categories",
-  "/dashboard/tenant/properties/rooms": "Room Management",
   "/dashboard/tenant/transactions": "Transactions",
   "/dashboard/tenant/reports/sales": "Sales Reports",
   "/dashboard/tenant/reports/properties": "Property Reports",

--- a/apps/web/src/components/tenant/tenant-sidebar.tsx
+++ b/apps/web/src/components/tenant/tenant-sidebar.tsx
@@ -41,7 +41,6 @@ const nav: Group[] = [
         label: "Property Categories",
         href: "/dashboard/tenant/properties/categories",
       },
-      { label: "Room Management", href: "/dashboard/tenant/properties/rooms" },
     ],
   },
 

--- a/apps/web/src/components/user-menu.tsx
+++ b/apps/web/src/components/user-menu.tsx
@@ -130,7 +130,7 @@ export function UserMenu() {
         {isTenant && (
           <DropdownMenuItem asChild>
             <Link
-              href="/dashboard/properties"
+              href="/dashboard/tenant/properties"
               className="w-full flex items-center gap-2"
             >
               <HiOutlineViewGrid className="h-4 w-4" /> My Listings

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "./auth";
+
+export async function middleware(request: NextRequest) {
+  const session = await auth();
+  const url = request.nextUrl.clone();
+  const pathname = url.pathname;
+
+  if (!session?.user) {
+    url.pathname = "/";
+    return NextResponse.redirect(url);
+  }
+
+  if (
+    pathname.startsWith("/dashboard/tenant") &&
+    session.user.role !== "TENANT"
+  ) {
+    url.pathname = "/";
+    return NextResponse.redirect(url);
+  }
+
+  if (
+    pathname.startsWith("/dashboard/guest") &&
+    session.user.role !== "GUEST"
+  ) {
+    url.pathname = "/";
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/dashboard/:path*"],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1759,9 +1759,9 @@
             }
         },
         "node_modules/@prisma/client": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.15.0.tgz",
-            "integrity": "sha512-wR2LXUbOH4cL/WToatI/Y2c7uzni76oNFND7+23ypLllBmIS8e3ZHhO+nud9iXSXKFt1SoM3fTZvHawg63emZw==",
+            "version": "6.16.1",
+            "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.1.tgz",
+            "integrity": "sha512-QaBCOY29lLAxEFFJgBPyW3WInCW52fJeQTmWx/h6YsP5u0bwuqP51aP0uhqFvhK9DaZPwvai/M4tSDYLVE9vRg==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1781,9 +1781,9 @@
             }
         },
         "node_modules/@prisma/config": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.15.0.tgz",
-            "integrity": "sha512-KMEoec9b2u6zX0EbSEx/dRpx1oNLjqJEBZYyK0S3TTIbZ7GEGoVyGyFRk4C72+A38cuPLbfQGQvgOD+gBErKlA==",
+            "version": "6.16.1",
+            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.16.1.tgz",
+            "integrity": "sha512-sz3uxRPNL62QrJ0EYiujCFkIGZ3hg+9hgC1Ae1HjoYuj0BxCqHua4JNijYvYCrh9LlofZDZcRBX3tHBfLvAngA==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1794,53 +1794,53 @@
             }
         },
         "node_modules/@prisma/debug": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.15.0.tgz",
-            "integrity": "sha512-y7cSeLuQmyt+A3hstAs6tsuAiVXSnw9T55ra77z0nbNkA8Lcq9rNcQg6PI00by/+WnE/aMRJ/W7sZWn2cgIy1g==",
+            "version": "6.16.1",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.16.1.tgz",
+            "integrity": "sha512-RWv/VisW5vJE4cDRTuAHeVedtGoItXTnhuLHsSlJ9202QKz60uiXWywBlVcqXVq8bFeIZoCoWH+R1duZJPwqLw==",
             "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/engines": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.15.0.tgz",
-            "integrity": "sha512-opITiR5ddFJ1N2iqa7mkRlohCZqVSsHhRcc29QXeldMljOf4FSellLT0J5goVb64EzRTKcIDeIsJBgmilNcKxA==",
+            "version": "6.16.1",
+            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.16.1.tgz",
+            "integrity": "sha512-EOnEM5HlosPudBqbI+jipmaW/vQEaF0bKBo4gVkGabasINHR6RpC6h44fKZEqx4GD8CvH+einD2+b49DQrwrAg==",
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "6.15.0",
-                "@prisma/engines-version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
-                "@prisma/fetch-engine": "6.15.0",
-                "@prisma/get-platform": "6.15.0"
+                "@prisma/debug": "6.16.1",
+                "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
+                "@prisma/fetch-engine": "6.16.1",
+                "@prisma/get-platform": "6.16.1"
             }
         },
         "node_modules/@prisma/engines-version": {
-            "version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
-            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb.tgz",
-            "integrity": "sha512-a/46aK5j6L3ePwilZYEgYDPrhBQ/n4gYjLxT5YncUTJJNRnTCVjPF86QdzUOLRdYjCLfhtZp9aum90W0J+trrg==",
+            "version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
+            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43.tgz",
+            "integrity": "sha512-ThvlDaKIVrnrv97ujNFDYiQbeMQpLa0O86HFA2mNoip4mtFqM7U5GSz2ie1i2xByZtvPztJlNRgPsXGeM/kqAA==",
             "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/fetch-engine": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.15.0.tgz",
-            "integrity": "sha512-xcT5f6b+OWBq6vTUnRCc7qL+Im570CtwvgSj+0MTSGA1o9UDSKZ/WANvwtiRXdbYWECpyC3CukoG3A04VTAPHw==",
+            "version": "6.16.1",
+            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.16.1.tgz",
+            "integrity": "sha512-fl/PKQ8da5YTayw86WD3O9OmKJEM43gD3vANy2hS5S1CnfW2oPXk+Q03+gUWqcKK306QqhjjIHRFuTZ31WaosQ==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "6.15.0",
-                "@prisma/engines-version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
-                "@prisma/get-platform": "6.15.0"
+                "@prisma/debug": "6.16.1",
+                "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
+                "@prisma/get-platform": "6.16.1"
             }
         },
         "node_modules/@prisma/get-platform": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.15.0.tgz",
-            "integrity": "sha512-Jbb+Xbxyp05NSR1x2epabetHiXvpO8tdN2YNoWoA/ZsbYyxxu/CO/ROBauIFuMXs3Ti+W7N7SJtWsHGaWte9Rg==",
+            "version": "6.16.1",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.16.1.tgz",
+            "integrity": "sha512-kUfg4vagBG7dnaGRcGd1c0ytQFcDj2SUABiuveIpL3bthFdTLI6PJeLEia6Q8Dgh+WhPdo0N2q0Fzjk63XTyaA==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "6.15.0"
+                "@prisma/debug": "6.16.1"
             }
         },
         "node_modules/@radix-ui/number": {
@@ -8519,15 +8519,15 @@
             }
         },
         "node_modules/prisma": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.15.0.tgz",
-            "integrity": "sha512-E6RCgOt+kUVtjtZgLQDBJ6md2tDItLJNExwI0XJeBc1FKL+Vwb+ovxXxuok9r8oBgsOXBA33fGDuE/0qDdCWqQ==",
+            "version": "6.16.1",
+            "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.1.tgz",
+            "integrity": "sha512-MFkMU0eaDDKAT4R/By2IA9oQmwLTxokqv2wegAErr9Rf+oIe7W2sYpE/Uxq0H2DliIR7vnV63PkC1bEwUtl98w==",
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/config": "6.15.0",
-                "@prisma/engines": "6.15.0"
+                "@prisma/config": "6.16.1",
+                "@prisma/engines": "6.16.1"
             },
             "bin": {
                 "prisma": "build/index.js"
@@ -10454,10 +10454,10 @@
             "name": "@repo/database",
             "dependencies": {
                 "@faker-js/faker": "^9.9.0",
-                "@prisma/client": "^6.13.0"
+                "@prisma/client": "^6.16.1"
             },
             "devDependencies": {
-                "prisma": "^6.13.0"
+                "prisma": "^6.16.1"
             }
         },
         "packages/schemas": {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -9,10 +9,10 @@
         "studio": "prisma studio"
     },
     "devDependencies": {
-        "prisma": "^6.13.0"
+        "prisma": "^6.16.1"
     },
     "dependencies": {
         "@faker-js/faker": "^9.9.0",
-        "@prisma/client": "^6.13.0"
+        "@prisma/client": "^6.16.1"
     }
 }


### PR DESCRIPTION
Add a new middleware to protect dashboard routes and enforce role-based access (TENANT / GUEST). Clean up tenant dashboard navigation and user menu links, remove stale room-management entries, and update authentication wiring on the web app to use JWT sessions (Prisma adapter commented out). Also include a small bugfix in API token generation (adds expiresIn) and bump Prisma/@prisma/client to 6.16.1.