### PR TITLE
feat(rooms): add RoomService, controller, router, and schemas; register room routes

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import propertyRouter from "./routers/property.route.js";
 import bookingsRouter from "./routers/booking.router.js";
 import emailRouter from "./routers/email.router.js";
 import categoryRouter from "./routers/category.router.js";
+import roomRouter from "./routers/room.router.js";
 
 export class App {
   app: Application;
@@ -37,6 +38,7 @@ export class App {
     this.app.use("/api/v1/properties", propertyRouter);
     this.app.use("/api/v1/bookings", bookingsRouter);
     this.app.use("/api/v1/categories", categoryRouter);
+    this.app.use("/api/v1/rooms", roomRouter);
     this.app.get("/api/v1/health", (request: Request, response: Response) =>
       response.status(200).json({ message: "API running!" })
     );

--- a/apps/api/src/controllers/room.controller.ts
+++ b/apps/api/src/controllers/room.controller.ts
@@ -1,0 +1,98 @@
+import { NextFunction, Request, Response } from "express";
+import { createRoomSchema, CreateRoomInput } from "@repo/schemas";
+import { roomService } from "@/services/room.service.js";
+
+export class RoomController {
+  createRoom = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const data = createRoomSchema.parse(request.body);
+      const { propertyId } = request.params;
+
+      const room = await roomService.createRoom(propertyId, data);
+      response.status(201).json({
+        message: "Room created successfully",
+        data: room,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getRoomsByProperty = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { propertyId } = request.params;
+      const rooms = await roomService.getRoomsByProperty(propertyId);
+
+      response.status(200).json({
+        message: "Rooms retrieved successfully",
+        data: rooms,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getRoomById = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { roomId } = request.params;
+      const room = await roomService.getRoomById(roomId);
+
+      response.status(200).json({
+        message: "Room retrieved successfully",
+        data: room,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  updateRoom = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { roomId } = request.params;
+      const data = createRoomSchema.partial().parse(request.body);
+
+      const room = await roomService.updateRoom(roomId, data);
+      response.status(200).json({
+        message: "Room updated successfully",
+        data: room,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  deleteRoom = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { roomId } = request.params;
+      await roomService.deleteRoom(roomId);
+
+      response.status(200).json({
+        message: "Room deleted successfully",
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+export const roomController = new RoomController();

--- a/apps/api/src/routers/room.router.ts
+++ b/apps/api/src/routers/room.router.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import { roomController } from "../controllers/room.controller.js";
+import { verifyTokenMiddleware } from "../middlewares/verifyToken.middleware.js";
+import { verifyRoleMiddleware } from "../middlewares/verifyRole.middleware.js";
+
+const router = Router();
+
+router.use(verifyTokenMiddleware);
+router.use(verifyRoleMiddleware);
+
+router.post("/property/:propertyId", roomController.createRoom);
+router.get("/property/:propertyId", roomController.getRoomsByProperty);
+
+router.get("/:roomId", roomController.getRoomById);
+router.put("/:roomId", roomController.updateRoom);
+
+router.delete("/:roomId", roomController.deleteRoom);
+
+export default router;

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -3,3 +3,4 @@ export * from "./search.schema.js";
 export * from "./property.schema.js";
 export * from "./booking.schema.js";
 export * from "./category.schema.js";
+export * from "./room.schema.js";

--- a/packages/schemas/src/property.schema.ts
+++ b/packages/schemas/src/property.schema.ts
@@ -45,7 +45,7 @@ export const getPropertiesQuerySchema = z.object({
   sortOrder: z.union([z.literal("asc"), z.literal("desc")]).optional(),
 });
 
-export const roomSchema = z.object({
+export const roomSummarySchema = z.object({
   name: z.string().optional(),
   basePrice: z.number(),
   beds: z.number().optional(),
@@ -65,7 +65,7 @@ export const propertyResponseSchema = propertySchema
     id: z.string(),
     PropertyCategory: propertyCategorySchema.optional().nullable(),
     CustomCategory: customCategorySchema.optional().nullable(),
-    Rooms: z.array(roomSchema),
+    Rooms: z.array(roomSummarySchema),
   });
 
 export type GetPropertiesParams = {
@@ -129,6 +129,6 @@ export type CreatePropertyPictureInput = z.infer<
 >;
 export type Property = z.infer<typeof createPropertyInputSchema>;
 export type GetPropertiesQuery = z.infer<typeof getPropertiesQuerySchema>;
-export type RoomResponse = z.infer<typeof roomSchema>;
+export type RoomResponse = z.infer<typeof roomSummarySchema>;
 export type PropertyCategoryResponse = z.infer<typeof propertyCategorySchema>;
 export type PropertyResponse = z.infer<typeof propertyResponseSchema>;

--- a/packages/schemas/src/room.schema.ts
+++ b/packages/schemas/src/room.schema.ts
@@ -13,7 +13,7 @@ export const createRoomSchema = z.object({
   capacity: z.number().int().min(1).default(1),
   bedType: z.enum(["KING", "QUEEN", "SINGLE", "TWIN"]).optional(),
   bedCount: z.number().int().min(1).default(1),
-  imageUrl: z.string().url().optional(),
+  imageUrl: z.url().optional(),
 });
 
 export const createRoomAvailabilitySchema = z.object({
@@ -35,7 +35,14 @@ export const createPriceAdjustmentSchema = z.object({
   dates: z.array(z.string()).optional(),
 });
 
+export const updateRoomSchema = createRoomSchema.partial();
+
+export const deleteRoomSchema = z.object({
+  roomId: z.uuid(),
+});
+
 export type CreateRoomInput = z.infer<typeof createRoomSchema>;
+export type UpdateRoomInput = z.infer<typeof updateRoomSchema>;
 export type CreateRoomAvailabilityInput = z.infer<
   typeof createRoomAvailabilitySchema
 >;


### PR DESCRIPTION
Adds backend CRUD for rooms (service, controller, router, routes, and schemas)

- API &  #routing
  - Add tenant-protected room.router with CRUD endpoints 

- Controller & service
  - Add RoomController for request handling, validation, and structured responses 
  - Add RoomService encapsulating business logic (property checks, related data handling, prevent deletion if bookings exist)
  
 - Schemas & types
   - Add new room schemas and export them from [index.ts]
   - Introduce roomSummarySchema and update property schema usage 
   - Add stricter URL validation plus updateRoomSchema and deleteRoomSchema; export related types