### PR TITLE
feat(location-picker): add interactive Google Maps location picker

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@react-google-maps/api": "^2.20.7",
     "@tanstack/react-query": "^5.85.6",
     "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/api/google-places/details/route.ts
+++ b/apps/web/src/app/api/google-places/details/route.ts
@@ -1,0 +1,42 @@
+import { Client } from "@googlemaps/google-maps-services-js";
+import { NextRequest, NextResponse } from "next/server";
+
+const googleMapsClient = new Client({});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const placeId = searchParams.get("place_id");
+
+    if (!placeId) {
+      return NextResponse.json(
+        { error: "Place ID is required" },
+        { status: 400 }
+      );
+    }
+
+    const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY;
+
+    if (!GOOGLE_MAPS_API_KEY) {
+      return NextResponse.json(
+        { error: "Google Maps API key not configured" },
+        { status: 500 }
+      );
+    }
+
+    const response = await googleMapsClient.placeDetails({
+      params: {
+        place_id: placeId,
+        key: GOOGLE_MAPS_API_KEY,
+        fields: ["formatted_address", "geometry", "address_components", "name"],
+      },
+    });
+
+    return NextResponse.json(response.data);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch place details" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/google-places/geocode/route.ts
+++ b/apps/web/src/app/api/google-places/geocode/route.ts
@@ -1,0 +1,52 @@
+import { Client } from "@googlemaps/google-maps-services-js";
+import { NextRequest, NextResponse } from "next/server";
+
+const googleMapsClient = new Client({});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const lat = searchParams.get("lat");
+    const lng = searchParams.get("lng");
+
+    if (!lat || !lng) {
+      return NextResponse.json(
+        { error: "Latitude and longitude are required" },
+        { status: 400 }
+      );
+    }
+
+    const latitude = parseFloat(lat);
+    const longitude = parseFloat(lng);
+
+    if (isNaN(latitude) || isNaN(longitude)) {
+      return NextResponse.json(
+        { error: "Invalid latitude or longitude" },
+        { status: 400 }
+      );
+    }
+
+    const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY;
+
+    if (!GOOGLE_MAPS_API_KEY) {
+      return NextResponse.json(
+        { error: "Google Maps API key not configured" },
+        { status: 500 }
+      );
+    }
+
+    const response = await googleMapsClient.reverseGeocode({
+      params: {
+        latlng: { lat: latitude, lng: longitude },
+        key: GOOGLE_MAPS_API_KEY,
+      },
+    });
+
+    return NextResponse.json(response.data);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch address details" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/test/route.ts
+++ b/apps/web/src/app/api/test/route.ts
@@ -1,5 +1,0 @@
-import { NextResponse } from "next/server";
-
-export async function GET() {
-  return NextResponse.json({ message: "Test endpoint working" });
-}

--- a/apps/web/src/components/tenant/property-creation/steps/location-step.tsx
+++ b/apps/web/src/components/tenant/property-creation/steps/location-step.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import React from "react";
 import { usePropertyCreation } from "../property-creation-context";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { LocationPicker } from "@/components/ui/location-picker";
 
 export function LocationStep() {
   const { formData, updateFormData } = usePropertyCreation();
@@ -13,12 +14,50 @@ export function LocationStep() {
     updateFormData({ [field]: value });
   };
 
+  const handleLocationSelect = (location: {
+    lat: number;
+    lng: number;
+    address: string;
+    city: string;
+    country: string;
+  }) => {
+    updateFormData({
+      latitude: location.lat,
+      longitude: location.lng,
+      address: location.address,
+      city: location.city,
+      country: location.country,
+    });
+  };
+
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Location Details</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
+        {apiKey && (
+          <div className="space-y-4">
+            <div>
+              <LocationPicker
+                onLocationSelect={handleLocationSelect}
+                apiKey={apiKey}
+                initialLocation={
+                  formData.latitude && formData.longitude
+                    ? {
+                        lat: formData.latitude,
+                        lng: formData.longitude,
+                      }
+                    : undefined
+                }
+                className="border rounded-lg p-4"
+              />
+            </div>
+          </div>
+        )}
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="space-y-2">
             <Label htmlFor="country">Country *</Label>
@@ -53,42 +92,6 @@ export function LocationStep() {
             rows={3}
             className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
           />
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label htmlFor="latitude">Latitude (Optional)</Label>
-            <Input
-              id="latitude"
-              type="number"
-              step="any"
-              min={-90}
-              max={90}
-              value={formData.latitude || ""}
-              onChange={(e) =>
-                handleChange("latitude", parseFloat(e.target.value) || 0)
-              }
-              placeholder="e.g., -6.2088"
-            />
-            <p className="text-sm text-gray-500">Between -90 and 90</p>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="longitude">Longitude (Optional)</Label>
-            <Input
-              id="longitude"
-              type="number"
-              step="any"
-              min={-180}
-              max={180}
-              value={formData.longitude || ""}
-              onChange={(e) =>
-                handleChange("longitude", parseFloat(e.target.value) || 0)
-              }
-              placeholder="e.g., 106.8456"
-            />
-            <p className="text-sm text-gray-500">Between -180 and 180</p>
-          </div>
         </div>
       </CardContent>
     </Card>

--- a/apps/web/src/components/ui/location-picker.tsx
+++ b/apps/web/src/components/ui/location-picker.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import React, { useState, useCallback, useRef } from "react";
+import { toast } from "sonner";
+import axios from "axios";
+import { GoogleMap, LoadScript, Marker } from "@react-google-maps/api";
+
+interface LocationPickerProps {
+  onLocationSelect: (location: {
+    lat: number;
+    lng: number;
+    address: string;
+    city: string;
+    country: string;
+  }) => void;
+  initialLocation?: {
+    lat: number;
+    lng: number;
+  };
+  apiKey: string;
+  className?: string;
+}
+
+const mapContainerStyle = {
+  width: "100%",
+  height: "400px",
+};
+
+const defaultCenter = {
+  lat: -6.2088,
+  lng: 106.8456,
+};
+
+const libraries: "places"[] = ["places"];
+
+export function LocationPicker({
+  onLocationSelect,
+  initialLocation,
+  apiKey,
+  className = "",
+}: LocationPickerProps) {
+  const [selectedLocation, setSelectedLocation] = useState<{
+    lat: number;
+    lng: number;
+  } | null>(initialLocation || null);
+  const [isLoading, setIsLoading] = useState(false);
+  const mapRef = useRef<google.maps.Map | null>(null);
+
+  const extractLocationDetails = useCallback(
+    async (lat: number, lng: number) => {
+      setIsLoading(true);
+      try {
+        const { data } = await axios.get(`/api/google-places/geocode`, {
+          params: { lat, lng },
+        });
+
+        if (data.results && data.results.length > 0) {
+          const result = data.results[0];
+          const addressComponents = result.address_components;
+
+          let city = "";
+          let country = "";
+
+          addressComponents.forEach(
+            (component: {
+              long_name: string;
+              short_name: string;
+              types: string[];
+            }) => {
+              if (component.types.includes("locality")) {
+                city = component.long_name;
+              } else if (
+                component.types.includes("administrative_area_level_1")
+              ) {
+                if (!city) city = component.long_name;
+              } else if (component.types.includes("country")) {
+                country = component.long_name;
+              }
+            }
+          );
+
+          onLocationSelect({
+            lat,
+            lng,
+            address: result.formatted_address,
+            city: city || "Unknown",
+            country: country || "Unknown",
+          });
+        }
+      } catch {
+        toast.error("Failed to retrieve address details. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [onLocationSelect]
+  );
+
+  const handleMapClick = useCallback(
+    (event: google.maps.MapMouseEvent) => {
+      if (event.latLng) {
+        const lat = event.latLng.lat();
+        const lng = event.latLng.lng();
+        setSelectedLocation({ lat, lng });
+        extractLocationDetails(lat, lng);
+      }
+    },
+    [extractLocationDetails]
+  );
+
+  const onMapLoad = useCallback((map: google.maps.Map) => {
+    mapRef.current = map;
+  }, []);
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      <LoadScript googleMapsApiKey={apiKey} libraries={libraries}>
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm text-gray-600">
+              Click anywhere on the map to set the location for your property.
+            </p>
+          </div>
+
+          <div className="border rounded-lg overflow-hidden">
+            <GoogleMap
+              mapContainerStyle={mapContainerStyle}
+              center={selectedLocation || defaultCenter}
+              zoom={selectedLocation ? 15 : 10}
+              onClick={handleMapClick}
+              onLoad={onMapLoad}
+              options={{
+                streetViewControl: false,
+                mapTypeControl: false,
+                fullscreenControl: false,
+              }}
+            >
+              {selectedLocation && (
+                <Marker
+                  position={selectedLocation}
+                  animation={google.maps.Animation.DROP}
+                />
+              )}
+            </GoogleMap>
+          </div>
+
+          {isLoading && (
+            <div className="text-center text-sm text-gray-500">
+              Getting location details...
+            </div>
+          )}
+        </div>
+      </LoadScript>
+    </div>
+  );
+}

--- a/apps/web/src/types/google-places.ts
+++ b/apps/web/src/types/google-places.ts
@@ -36,5 +36,58 @@ export interface AutocompleteErrorResponse {
 }
 
 export type LocationSearchResult = PlacePrediction & {
-  id: string; // Using place_id as the id for React keys
+  id: string;
 };
+
+export interface PlaceDetailsResponse {
+  result: PlaceDetails;
+  status: string;
+  error_message?: string;
+}
+
+export interface PlaceDetails {
+  formatted_address: string;
+  geometry: {
+    location: {
+      lat: number;
+      lng: number;
+    };
+    viewport?: {
+      northeast: { lat: number; lng: number };
+      southwest: { lat: number; lng: number };
+    };
+  };
+  address_components: AddressComponent[];
+  name?: string;
+  place_id: string;
+}
+
+export interface AddressComponent {
+  long_name: string;
+  short_name: string;
+  types: string[];
+}
+
+export interface GeocodeResponse {
+  results: GeocodeResult[];
+  status: string;
+  error_message?: string;
+}
+
+export interface GeocodeResult {
+  formatted_address: string;
+  address_components: AddressComponent[];
+  geometry: {
+    location: {
+      lat: number;
+      lng: number;
+    };
+    location_type: string;
+    viewport?: {
+      northeast: { lat: number; lng: number };
+      southwest: { lat: number; lng: number };
+    };
+  };
+  place_id: string;
+  types: string[];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,6 +118,7 @@
                 "@radix-ui/react-separator": "^1.1.7",
                 "@radix-ui/react-slot": "^1.2.3",
                 "@radix-ui/react-tabs": "^1.1.13",
+                "@react-google-maps/api": "^2.20.7",
                 "@tanstack/react-query": "^5.85.6",
                 "axios": "^1.11.0",
                 "class-variance-authority": "^0.7.1",
@@ -905,6 +906,22 @@
                 "axios": "^1.5.1",
                 "query-string": "<8.x",
                 "retry-axios": "<3.x"
+            }
+        },
+        "node_modules/@googlemaps/js-api-loader": {
+            "version": "1.16.8",
+            "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.8.tgz",
+            "integrity": "sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@googlemaps/markerclusterer": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.5.3.tgz",
+            "integrity": "sha512-x7lX0R5yYOoiNectr10wLgCBasNcXFHiADIBdmn7jQllF2B5ENQw5XtZK+hIw4xnV0Df0xhN4LN98XqA5jaiOw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "supercluster": "^8.0.1"
             }
         },
         "node_modules/@googlemaps/url-signature": {
@@ -2797,6 +2814,36 @@
             "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
             "license": "MIT"
         },
+        "node_modules/@react-google-maps/api": {
+            "version": "2.20.7",
+            "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.20.7.tgz",
+            "integrity": "sha512-ys7uri3V6gjhYZUI43srHzSKDC6/jiKTwHNlwXFTvjeaJE3M3OaYBt9FZKvJs8qnOhL6i6nD1BKJoi1KrnkCkg==",
+            "license": "MIT",
+            "dependencies": {
+                "@googlemaps/js-api-loader": "1.16.8",
+                "@googlemaps/markerclusterer": "2.5.3",
+                "@react-google-maps/infobox": "2.20.0",
+                "@react-google-maps/marker-clusterer": "2.20.0",
+                "@types/google.maps": "3.58.1",
+                "invariant": "2.2.4"
+            },
+            "peerDependencies": {
+                "react": "^16.8 || ^17 || ^18 || ^19",
+                "react-dom": "^16.8 || ^17 || ^18 || ^19"
+            }
+        },
+        "node_modules/@react-google-maps/infobox": {
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.20.0.tgz",
+            "integrity": "sha512-03PJHjohhaVLkX6+NHhlr8CIlvUxWaXhryqDjyaZ8iIqqix/nV8GFdz9O3m5OsjtxtNho09F/15j14yV0nuyLQ==",
+            "license": "MIT"
+        },
+        "node_modules/@react-google-maps/marker-clusterer": {
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.20.0.tgz",
+            "integrity": "sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw==",
+            "license": "MIT"
+        },
         "node_modules/@repo/api": {
             "resolved": "apps/api",
             "link": true
@@ -3285,6 +3332,12 @@
                 "@types/range-parser": "*",
                 "@types/send": "*"
             }
+        },
+        "node_modules/@types/google.maps": {
+            "version": "3.58.1",
+            "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+            "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+            "license": "MIT"
         },
         "node_modules/@types/http-errors": {
             "version": "2.0.5",
@@ -5981,7 +6034,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-glob": {
@@ -6666,6 +6718,15 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
+            }
+        },
         "node_modules/ioredis": {
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
@@ -7179,7 +7240,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/js-yaml": {
@@ -7296,6 +7356,12 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/kdbush": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+            "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+            "license": "ISC"
         },
         "node_modules/keyv": {
             "version": "4.5.4",
@@ -7690,7 +7756,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -9792,6 +9857,15 @@
                 "babel-plugin-macros": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/supercluster": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+            "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+            "license": "ISC",
+            "dependencies": {
+                "kdbush": "^4.0.2"
             }
         },
         "node_modules/supports-color": {


### PR DESCRIPTION
**Frontend: Location Picker Integration**

* Added a new `LocationPicker` component using `@react-google-maps/api` to enable users to select a property location on a map, which then fetches and auto-fills address, city, and country details. 
* Updated the property creation `LocationStep` to use the new `LocationPicker` component, removing manual latitude/longitude inputs and wiring the picker to update form data. 
* Added the `@react-google-maps/api` dependency to the project. 

**Backend: Google Places API Endpoints**

* Added a new API endpoint for place details lookup using Google Maps API, which returns formatted address, geometry, and address components for a given place ID.
* Added a new API endpoint for reverse geocoding (lat/lng to address) using Google Maps API. 

**Types and Cleanup**

* Extended Google Places-related TypeScript types to cover place details and geocode responses. 
* Removed the unused test API endpoint. 