### PR TITLE
feat(rooms): add image upload & preview, refactor auth, and coerce numeric schema

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -33,7 +33,7 @@ export class App {
   }
 
   setupRoutes() {
-    this.app.use("/emails", emailRouter); //test
+    this.app.use("/emails", emailRouter);
     this.app.use("/api/v1/auth", authRouter);
     this.app.use("/api/v1/properties", propertyRouter);
     this.app.use("/api/v1/bookings", bookingsRouter);

--- a/apps/api/src/controllers/room.controller.ts
+++ b/apps/api/src/controllers/room.controller.ts
@@ -1,15 +1,17 @@
 import { NextFunction, Request, Response } from "express";
 import {
   createRoomSchema,
-  CreateRoomInput,
   blockRoomDatesSchema,
   unblockRoomDatesSchema,
   getRoomAvailabilitySchema,
   createPriceAdjustmentSchema,
 } from "@repo/schemas";
 import { roomService } from "@/services/room.service.js";
+import { FileService } from "@/services/file.service.js";
 
 export class RoomController {
+  private fileService = new FileService();
+
   createRoom = async (
     request: Request,
     response: Response,
@@ -17,6 +19,13 @@ export class RoomController {
   ) => {
     try {
       const data = createRoomSchema.parse(request.body);
+
+      if (request.file) {
+        const secureUrl = await this.fileService.uploadPicture(
+          request.file.path
+        );
+        data.imageUrl = secureUrl;
+      }
       const { propertyId } = request.params;
 
       const room = await roomService.createRoom(propertyId, data);
@@ -73,6 +82,13 @@ export class RoomController {
     try {
       const { roomId } = request.params;
       const data = createRoomSchema.partial().parse(request.body);
+
+      if (request.file) {
+        const secureUrl = await this.fileService.uploadPicture(
+          request.file.path
+        );
+        data.imageUrl = secureUrl;
+      }
 
       const room = await roomService.updateRoom(roomId, data);
       response.status(200).json({

--- a/apps/api/src/routers/room.router.ts
+++ b/apps/api/src/routers/room.router.ts
@@ -2,17 +2,22 @@ import { Router } from "express";
 import { roomController } from "../controllers/room.controller.js";
 import { verifyTokenMiddleware } from "../middlewares/verifyToken.middleware.js";
 import { verifyRoleMiddleware } from "../middlewares/verifyRole.middleware.js";
+import { upload } from "../middlewares/upload.middleware.js";
 
 const router = Router();
 
 router.use(verifyTokenMiddleware);
 router.use(verifyRoleMiddleware);
 
-router.post("/property/:propertyId", roomController.createRoom);
+router.post(
+  "/property/:propertyId",
+  upload.single("imageFile"),
+  roomController.createRoom
+);
 router.get("/property/:propertyId", roomController.getRoomsByProperty);
 
 router.get("/:roomId", roomController.getRoomById);
-router.put("/:roomId", roomController.updateRoom);
+router.put("/:roomId", upload.single("imageFile"), roomController.updateRoom);
 router.delete("/:roomId", roomController.deleteRoom);
 
 router.get("/:roomId/availability", roomController.getRoomAvailability);

--- a/apps/web/src/components/tenant/property-creation/steps/photos-step.tsx
+++ b/apps/web/src/components/tenant/property-creation/steps/photos-step.tsx
@@ -105,7 +105,9 @@ export function PhotosStep() {
       URL.revokeObjectURL(photoToRemove.preview);
     }
 
-    const updatedPictures = pictures.filter((_: PictureItem, i: number) => i !== index);
+    const updatedPictures = pictures.filter(
+      (_: PictureItem, i: number) => i !== index
+    );
     updateFormData({ pictures: updatedPictures });
   };
 

--- a/apps/web/src/components/tenant/room-list.tsx
+++ b/apps/web/src/components/tenant/room-list.tsx
@@ -254,10 +254,6 @@ export function RoomList({ rooms, loading, onEdit, onDelete }: RoomListProps) {
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end" className="w-48">
-                          <DropdownMenuItem onClick={() => onEdit(room)}>
-                            <Edit className="h-4 w-4 mr-2" />
-                            Edit Room Details
-                          </DropdownMenuItem>
                           <DropdownMenuItem
                             onClick={() => handleManageAvailability(room)}
                           >

--- a/packages/schemas/src/room.schema.ts
+++ b/packages/schemas/src/room.schema.ts
@@ -3,17 +3,17 @@ import z from "zod";
 export const roomSchema = z.object({
   name: z.string().optional(),
   description: z.string().optional(),
-  basePrice: z.number(),
-  beds: z.number().optional(),
+  basePrice: z.coerce.number(),
+  beds: z.coerce.number().optional(),
 });
 
 export const createRoomSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
-  basePrice: z.number().positive(),
-  capacity: z.number().int().min(1).default(1),
+  basePrice: z.coerce.number().positive(),
+  capacity: z.coerce.number().int().min(1).default(1),
   bedType: z.enum(["KING", "QUEEN", "SINGLE", "TWIN"]).optional(),
-  bedCount: z.number().int().min(1).default(1),
+  bedCount: z.coerce.number().int().min(1).default(1),
   imageUrl: z.url().optional(),
 });
 
@@ -44,7 +44,7 @@ export const createPriceAdjustmentSchema = z.object({
   startDate: z.string(),
   endDate: z.string(),
   adjustType: z.enum(["PERCENTAGE", "NOMINAL"]),
-  adjustValue: z.number(),
+  adjustValue: z.coerce.number(),
   applyAllDates: z.boolean().optional().default(true),
   dates: z.array(z.string()).optional(),
 });


### PR DESCRIPTION
**Room Image Upload & Handling**

* Added image upload capability to room creation and update endpoints in the API, using the new `upload` middleware and integrating with `FileService` for secure storage. The backend now saves and returns the image URL when a file is provided. 
* Updated the room form in the frontend to allow users to select and preview an image file before submitting. The form now sends a `FormData` payload with the image file when present.

**API Authentication & Refactoring**

* Refactored API usage in the frontend to set the `Authorization` header directly on a shared API instance, ensuring proper authentication for all room-related requests and cleaning up headers after each call. 

**Validation Improvements**

* Updated room-related schemas to use `z.coerce.number()` for numeric fields, allowing string inputs to be coerced to numbers and improving compatibility with form submissions. 
* 
**Minor Code Cleanup**

* Removed a test comment from the email router setup in the API app file for clarity. 
* Minor formatting improvements in the photo step component for consistency. 

**UI Adjustments**

* Removed the "Edit Room Details" option from the room list dropdown menu in the frontend. 