### PR TITLE
feat(web): improve home UI, add PagerControls, and refine marquee & pagination

### DIFF
--- a/apps/web/src/components/home/featured-properties.tsx
+++ b/apps/web/src/components/home/featured-properties.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
 import { Users, Star } from "lucide-react";
+import PagerControls from "@/components/ui/pager-controls";
 import { useProperties } from "@/hooks/useProperties";
 import type { Property } from "@/types/property";
 import { useEffect, useState } from "react";
@@ -41,15 +42,15 @@ export default function FeaturedProperties() {
   return (
     <section className="w-full py-6 md:py-12">
       <div className="container mx-auto max-w-7xl px-4 md:px-6">
-        <div className="mb-4">
-          <div className="mb-2">
-            <h2 className="text-2xl font-bold sm:text-4xl mb-0 text-slate-900">
-              Featured Properties
-            </h2>
-            <p className="text-slate-600">Handpicked stays for you</p>
+        <div className="relative">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-2xl font-bold sm:text-4xl text-slate-900">
+                Featured Properties
+              </h2>
+              <p className="text-slate-600">Handpicked stays for you</p>
+            </div>
           </div>
-
-          {/* top area (title) */}
         </div>
 
         <div className="overflow-hidden">
@@ -77,8 +78,8 @@ export default function FeaturedProperties() {
                 style={{ flex: `0 0 ${100 / slidesPerView}%` }}
                 className="px-2"
               >
-                <Card className="overflow-hidden hover:shadow-lg transition-shadow">
-                  <div className="aspect-[4/3] bg-slate-200 relative overflow-hidden">
+                <Card className="overflow-hidden transition-shadow border-none shadow-none bg-transparent">
+                  <div className="aspect-[4/3] bg-slate-200 relative rounded-xl overflow-hidden">
                     <Image
                       src={
                         property.imageUrl ||
@@ -90,11 +91,11 @@ export default function FeaturedProperties() {
                       className="w-full h-full object-cover"
                     />
                   </div>
-                  <CardContent className="p-4">
-                    <div className="text-sm text-slate-500 mb-2">
+                  <CardContent className="p-1">
+                    <div className="text-sm text-slate-500 mb-0.5">
                       {property.city}
                     </div>
-                    <CardTitle className="text-lg mb-2 line-clamp-1">
+                    <CardTitle className="text-lg mb-0.5 line-clamp-1">
                       <Link
                         href={`/properties/${property.slug}`}
                         className="hover:text-blue-600"
@@ -102,8 +103,7 @@ export default function FeaturedProperties() {
                         {property.name}
                       </Link>
                     </CardTitle>
-
-                    <div className="flex items-center gap-4 text-sm text-slate-600 mb-3">
+                    <div className="flex items-center gap-2 text-sm text-slate-600 mb-1">
                       <div className="flex items-center gap-1">
                         <Users className="w-4 h-4" />
                         <span>{property.maxGuests} Guests</span>
@@ -112,8 +112,7 @@ export default function FeaturedProperties() {
                         <span>{property.Rooms.length || 0} Rooms</span>
                       </div>
                     </div>
-
-                    <p className="text-sm text-slate-600 mb-4 line-clamp-2">
+                    <p className="text-sm text-slate-600 mb-1 line-clamp-2">
                       {property.description}
                     </p>
 
@@ -137,37 +136,12 @@ export default function FeaturedProperties() {
             ))}
           </div>
         </div>
-        <div className="flex items-center gap-4 mt-4">
-          <div className="flex-1">
-            <div className="w-full h-2 bg-slate-100 rounded overflow-hidden">
-              <div
-                className="h-2 bg-primary transition-[width] duration-300"
-                style={{
-                  width: maxIndex > 0 ? `${(current / maxIndex) * 100}%` : "0%",
-                }}
-              />
-            </div>
-          </div>
-
-          <div className="flex gap-2">
-            <button
-              aria-label="Previous"
-              onClick={prev}
-              disabled={current === 0}
-              className="h-9 w-9 rounded bg-white flex items-center justify-center disabled:opacity-50"
-            >
-              ‹
-            </button>
-            <button
-              aria-label="Next"
-              onClick={next}
-              disabled={current === maxIndex}
-              className="h-9 w-9 rounded bg-primary text-primary-foreground flex items-center justify-center disabled:opacity-50 hover:bg-primary/90"
-            >
-              ›
-            </button>
-          </div>
-        </div>
+        <PagerControls
+          current={current}
+          maxIndex={maxIndex}
+          onPrev={prev}
+          onNext={next}
+        />
       </div>
     </section>
   );

--- a/apps/web/src/components/home/hero-section.tsx
+++ b/apps/web/src/components/home/hero-section.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
@@ -41,27 +40,7 @@ export default function HeroSection() {
               Find Your Perfect Rental Property
             </h1>
             <p className="mx-auto max-w-[700px] text-xl text-slate-200 md:text-2xl">
-              for{" "}
-              <Link
-                href="/search?type=holidays"
-                className="text-blue-400 hover:underline"
-              >
-                holidays
-              </Link>
-              ,{" "}
-              <Link
-                href="/search?type=business"
-                className="text-blue-400 hover:underline"
-              >
-                business trips
-              </Link>{" "}
-              and{" "}
-              <Link
-                href="/search?type=family"
-                className="text-blue-400 hover:underline"
-              >
-                family stays
-              </Link>
+              for holidays, business trips and family stays
             </p>
           </div>
         </div>

--- a/apps/web/src/components/home/popular-destinations.tsx
+++ b/apps/web/src/components/home/popular-destinations.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Card } from "@/components/ui/card";
 import { useEffect, useRef, useState } from "react";
+import PagerControls from "@/components/ui/pager-controls";
 
 const destinations = [
   {
@@ -11,28 +12,28 @@ const destinations = [
     name: "BALI BEACHES",
     image:
       "https://images.unsplash.com/photo-1537953773345-d172ccf13cf1?auto=format&fit=crop&w=800&q=80",
-    href: "/search?location=bali",
+    href: "/properties?location=bali",
   },
   {
     id: 2,
     name: "JAKARTA CITY",
     image:
       "https://images.unsplash.com/photo-1555993539-1732b0258ff1?auto=format&fit=crop&w=800&q=80",
-    href: "/search?location=jakarta",
+    href: "/properties?location=jakarta",
   },
   {
     id: 3,
     name: "YOGYAKARTA CULTURE",
     image:
       "https://images.unsplash.com/photo-1596402184320-417e7178b2cd?auto=format&fit=crop&w=800&q=80",
-    href: "/search?location=yogyakarta",
+    href: "/properties?location=yogyakarta",
   },
   {
     id: 4,
     name: "BANDUNG HILLS",
     image:
       "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=800&q=80",
-    href: "/search?location=bandung",
+    href: "/properties?location=bandung",
   },
 ];
 
@@ -85,35 +86,12 @@ export default function PopularDestinations() {
                 Discover the most sought-after destinations across Indonesia
               </p>
             </div>
-
-            <div className="flex gap-2">
-              {slidesPerView === 1 && (
-                <>
-                  <button
-                    aria-label="Previous"
-                    onClick={prev}
-                    disabled={current === 0}
-                    className="h-9 w-9 rounded bg-white flex items-center justify-center disabled:opacity-50"
-                  >
-                    ‹
-                  </button>
-                  <button
-                    aria-label="Next"
-                    onClick={next}
-                    disabled={current === maxIndex}
-                    className="h-9 w-9 rounded bg-white flex items-center justify-center disabled:opacity-50"
-                  >
-                    ›
-                  </button>
-                </>
-              )}
-            </div>
           </div>
 
           {slidesPerView === 2 ? (
             <div className="grid grid-cols-2 gap-4 md:gap-0">
               {destinations.map((destination) => (
-                <div key={destination.id} className="p-2">
+                <div key={destination.id}>
                   <Card className="overflow-hidden transition-all duration-300 group cursor-pointer shadow-none border-0 bg-transparent my-0 !p-0">
                     <Link href={destination.href} className="block">
                       <div className="relative overflow-hidden aspect-[2/3] md:aspect-[16/9] lg:aspect-[2/3]">
@@ -180,6 +158,15 @@ export default function PopularDestinations() {
                 ))}
               </div>
             </div>
+          )}
+          {/* Mobile controls + progress bar (matches FeaturedProperties) */}
+          {slidesPerView === 1 && (
+            <PagerControls
+              current={current}
+              maxIndex={maxIndex}
+              onPrev={prev}
+              onNext={next}
+            />
           )}
         </div>
       </div>

--- a/apps/web/src/components/home/property-categories.tsx
+++ b/apps/web/src/components/home/property-categories.tsx
@@ -67,23 +67,25 @@ export default function PropertyCategories() {
   return (
     <section className="w-full py-12 md:py-20 bg-white">
       <div className="container mx-auto max-w-7xl px-4 md:px-6">
-        <div className="mb-6">
-          <h2 className="text-3xl font-bold sm:text-4xl mb-2 text-slate-900">
-            Property Categories
-          </h2>
-          <p className="text-slate-600">
-            Browse properties by popular categories
-          </p>
+        <div className="relative">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-3xl font-bold sm:text-4xl text-slate-900">
+                Property Categories
+              </h2>
+              <p className="text-slate-600">Browse properties by popular categories</p>
+            </div>
+          </div>
         </div>
 
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 md:gap-6 items-stretch">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 md:gap-4 items-stretch">
           {categories.map((c) => (
             <Card
               key={c.id}
               className="overflow-hidden transition-all duration-300 group cursor-pointer shadow-none border-0 bg-transparent my-0 !p-0"
             >
               <Link href={c.href} className="block">
-                <div className="relative overflow-hidden rounded-lg h-40 md:h-44 lg:h-44">
+                <div className="relative overflow-hidden rounded-md h-36 md:h-40 lg:h-40">
                   <Image
                     src={c.image}
                     alt={c.name}
@@ -93,8 +95,8 @@ export default function PropertyCategories() {
 
                   <div className="absolute inset-0 bg-black/30 group-hover:bg-black/20 transition-colors duration-300"></div>
 
-                  <div className="absolute left-4 bottom-4 pr-4">
-                    <h3 className="text-lg md:text-xl font-semibold text-white leading-tight">
+                  <div className="absolute left-3 bottom-3 pr-2">
+                    <h3 className="text-base md:text-lg font-semibold text-white leading-tight">
                       {c.name}
                     </h3>
                   </div>
@@ -103,9 +105,9 @@ export default function PropertyCategories() {
             </Card>
           ))}
           <div className="col-span-2 sm:col-span-1 lg:col-span-2 ">
-            <div className="h-40 md:h-44 rounded-lg border border-slate-200 flex items-center justify-center p-6">
+            <div className="h-36 md:h-40 rounded-md border border-slate-200 flex items-center justify-center p-4">
               <Link
-                href="/search"
+                href="/properties"
                 className="w-full h-full flex items-center justify-center"
               >
                 <span className="text-lg md:text-xl font-semibold text-slate-900">

--- a/apps/web/src/components/home/running-text.tsx
+++ b/apps/web/src/components/home/running-text.tsx
@@ -12,23 +12,50 @@ export default function RunningText() {
   return (
     <section className="w-full bg-slate-50 border-t border-b border-slate-100">
       <div className="overflow-hidden py-2">
-        <div className="inline-flex whitespace-nowrap items-center w-[200%] marquee">
-          <div className="inline-flex items-center pr-40">
-            <span className="inline-block pr-40">{track}</span>
-          </div>
-          <div className="inline-flex items-center pr-40">
-            <span className="inline-block pr-40">{track}</span>
+        <div className="marquee">
+          <div className="marquee__inner">
+            <div className="marquee__item">
+              <span className="marquee__text">{track}</span>
+            </div>
+            <div className="marquee__item">
+              <span className="marquee__text">{track}</span>
+            </div>
           </div>
         </div>
       </div>
 
       <style>{`
-        @keyframes marquee {
-          0% { transform: translateX(0%); }
-          100% { transform: translateX(-50%); }
-        }
+        /* Seamless marquee: use translate3d, flex layout and prevent flex items from shrinking */
+        :root { --marquee-duration: 22s; --marquee-gap: 4rem; }
+
         .marquee {
-          animation: marquee 22s linear infinite;
+          overflow: hidden;
+        }
+
+        .marquee__inner {
+          display: flex;
+          width: 200%; /* two copies side-by-side */
+          align-items: center;
+          animation: marquee var(--marquee-duration) linear infinite;
+          will-change: transform;
+        }
+
+        .marquee__item {
+          display: inline-flex;
+          flex: 0 0 50%; /* each item takes half of the inner width */
+          align-items: center;
+          padding-right: var(--marquee-gap);
+        }
+
+        .marquee__text {
+          display: inline-block;
+          white-space: nowrap;
+          padding-right: var(--marquee-gap);
+        }
+
+        @keyframes marquee {
+          0% { transform: translate3d(0, 0, 0); }
+          100% { transform: translate3d(-50%, 0, 0); }
         }
       `}</style>
     </section>

--- a/apps/web/src/components/home/why-choose-us.tsx
+++ b/apps/web/src/components/home/why-choose-us.tsx
@@ -1,24 +1,24 @@
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
-import { Search, Star, Users } from "lucide-react";
+import { CalendarCheck, Gift, Headphones } from "lucide-react";
 
 export default function WhyChooseUs() {
   const items = [
     {
-      id: "curated",
-      title: "Curated stays",
-      desc: "Only quality properties, vetted by our team.",
+      id: "flexible",
+      title: "Flexible bookings",
+      desc: "Change or cancel your reservation with minimal fuss and clear policies.",
       img: "https://images.unsplash.com/photo-1505691723518-36a2f6f3a8b7?auto=format&fit=crop&w=800&q=80",
     },
     {
-      id: "trusted",
-      title: "Trusted hosts",
-      desc: "Hosts rated for reliability and great service.",
+      id: "perks",
+      title: "Perks & savings",
+      desc: "Unlock exclusive discounts, bundled extras, and member-only offers.",
       img: "https://images.unsplash.com/photo-1527980965255-d3b416303d12?auto=format&fit=crop&w=800&q=80",
     },
     {
-      id: "prices",
-      title: "Best prices",
-      desc: "Transparent pricing — no hidden fees.",
+      id: "support",
+      title: "24/7 customer support",
+      desc: "Get help any time, from booking to check-out — we're always available.",
       img: "https://images.unsplash.com/photo-1496412705862-e0088f16f791?auto=format&fit=crop&w=800&q=80",
     },
   ];
@@ -37,14 +37,14 @@ export default function WhyChooseUs() {
                 className="flex items-center justify-center w-16 h-16 border-r border-slate-100"
                 aria-hidden
               >
-                {it.id === "curated" && (
-                  <Search className="w-6 h-6 text-sky-600" />
+                {it.id === "flexible" && (
+                  <CalendarCheck className="w-6 h-6 text-sky-600" />
                 )}
-                {it.id === "trusted" && (
-                  <Star className="w-6 h-6 text-purple-600" />
+                {it.id === "perks" && (
+                  <Gift className="w-6 h-6 text-purple-600" />
                 )}
-                {it.id === "prices" && (
-                  <Users className="w-6 h-6 text-orange-600" />
+                {it.id === "support" && (
+                  <Headphones className="w-6 h-6 text-orange-600" />
                 )}
               </div>
 

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-2 rounded-xl border shadow-sm",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/pager-controls.tsx
+++ b/apps/web/src/components/ui/pager-controls.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React from "react";
+
+type Props = {
+  current: number;
+  maxIndex: number;
+  onPrev: () => void;
+  onNext: () => void;
+  className?: string;
+  onJump?: (index: number) => void;
+};
+
+export default function PagerControls({
+  current,
+  maxIndex,
+  onPrev,
+  onNext,
+  className = "",
+  onJump,
+}: Props) {
+  const trackRef = React.useRef<HTMLDivElement | null>(null);
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (!trackRef.current || typeof onJump !== "function") return;
+    const rect = trackRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const ratio = Math.max(0, Math.min(1, x / rect.width));
+    const index = Math.round(ratio * maxIndex);
+    onJump(index);
+  };
+
+  return (
+    <div className={`flex items-center gap-4 mt-4 ${className}`}>
+      <div className="flex-1">
+        <div
+          ref={trackRef}
+          onClick={handleClick}
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={maxIndex}
+          aria-valuenow={current}
+          className="w-full h-2 bg-slate-100 rounded overflow-hidden cursor-pointer"
+        >
+          <div
+            className="h-2 bg-primary transition-[width] duration-300"
+            style={{
+              width: maxIndex > 0 ? `${(current / maxIndex) * 100}%` : "0%",
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          aria-label="Previous"
+          onClick={onPrev}
+          disabled={current === 0}
+          className="h-9 w-9 rounded bg-white flex items-center justify-center disabled:opacity-50"
+        >
+          ‹
+        </button>
+        <button
+          aria-label="Next"
+          onClick={onNext}
+          disabled={current === maxIndex}
+          className="h-9 w-9 rounded bg-primary text-primary-foreground flex items-center justify-center disabled:opacity-50 hover:bg-primary/90"
+        >
+          ›
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Introduces a reusable PagerControls component (progress track + prev/next) for carousels.
- Replaces duplicated carousel controls in home components with PagerControls.
- Refines home layout and card styles (spacing, rounded corners, padding).
- Refactors RunningText marquee for smoother animation and consistent CSS variables.
- Reworks Pagination to a client-side progress track with click-to-jump + prev/next.
- Updated links: destinations/categories use /properties?....
- Manual checks: home carousels, marquee animation, and pagination prev/next + click-to-jump.