### PR TITLE
feat(property): add backend property update API and frontend tenant edit UI

### DIFF
--- a/apps/api/src/routers/property.route.ts
+++ b/apps/api/src/routers/property.route.ts
@@ -23,6 +23,19 @@ router.get(
   verifyRoleMiddleware,
   propertyController.getPropertiesByTenant
 );
+router.get(
+  "/:id",
+  verifyTokenMiddleware,
+  verifyRoleMiddleware,
+  propertyController.getPropertyById
+);
+router.put(
+  "/:id",
+  verifyTokenMiddleware,
+  verifyRoleMiddleware,
+  upload.fields([{ name: "propertyImages", maxCount: 10 }]),
+  propertyController.updateProperty
+);
 router.delete(
   "/:propertyId",
   verifyTokenMiddleware,

--- a/apps/web/src/app/dashboard/tenant/properties/[id]/edit/page.tsx
+++ b/apps/web/src/app/dashboard/tenant/properties/[id]/edit/page.tsx
@@ -15,8 +15,5 @@ export default async function EditPropertyPage({ params: { id } }: PageProps) {
     redirect("/auth/signin");
   }
 
-  // TODO: Fetch property data and pass to form
-  // const property = await getPropertyById(id);
-
   return <EditPropertyForm propertyId={id} />;
 }

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-2 rounded-xl border shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/location-picker.tsx
+++ b/apps/web/src/components/ui/location-picker.tsx
@@ -42,6 +42,22 @@ export function LocationPicker({
     onMapLoad,
   } = useLocationPicker({ onLocationSelect, initialLocation });
 
+  interface GoogleWindow {
+    google?: {
+      maps?: {
+        Animation?: {
+          DROP?: number;
+        };
+      };
+    };
+  }
+
+  const getMarkerAnimation = (): number | undefined => {
+    if (typeof window === "undefined") return undefined;
+    const gw = window as unknown as GoogleWindow;
+    return gw.google?.maps?.Animation?.DROP as number | undefined;
+  };
+
   return (
     <div className={`space-y-4 ${className}`}>
       <LoadScript googleMapsApiKey={apiKey} libraries={["places"]}>
@@ -68,13 +84,6 @@ export function LocationPicker({
             </div>
           </div>
 
-          <div>
-            <p className="text-sm text-gray-600">
-              Search for a location or click anywhere on the map to set the
-              location for your property.
-            </p>
-          </div>
-
           <div className="border rounded-lg overflow-hidden">
             <GoogleMap
               mapContainerStyle={{
@@ -99,7 +108,7 @@ export function LocationPicker({
               {selectedLocation && (
                 <Marker
                   position={selectedLocation}
-                  animation={google.maps.Animation.DROP}
+                  animation={getMarkerAnimation()}
                 />
               )}
             </GoogleMap>

--- a/packages/schemas/src/property.schema.ts
+++ b/packages/schemas/src/property.schema.ts
@@ -123,7 +123,29 @@ export const createPropertyInputSchema = z
   })
   .and(createPropertyCategoryInput);
 
+export const updatePropertyInputSchema = z.object({
+  name: z.string().max(100).optional(),
+  description: z.string().optional(),
+  country: z.string().max(60).optional(),
+  city: z.string().max(100).optional(),
+  address: z.string().optional(),
+  latitude: z.number().min(-90).max(90).optional().nullable(),
+  longitude: z.number().min(-180).max(180).optional().nullable(),
+  maxGuests: z.number().int().min(1).optional(),
+  pictures: z.array(createPropertyPictureSchema).optional(),
+  facilities: z.array(createFacilitySchema).optional(),
+  propertyCategoryId: z.uuid().optional(),
+  customCategoryId: z.uuid().optional(),
+  customCategory: z
+    .object({
+      name: z.string().min(1),
+      description: z.string().optional(),
+    })
+    .optional(),
+});
+
 export type CreatePropertyInput = z.infer<typeof createPropertyInputSchema>;
+export type UpdatePropertyInput = z.infer<typeof updatePropertyInputSchema>;
 export type CreatePropertyPictureInput = z.infer<
   typeof createPropertyPictureSchema
 >;


### PR DESCRIPTION
### API Enhancements

* Added `getPropertyById` and `updateProperty` controller methods in `property.controller.ts` to allow tenants to fetch and update property details, including handling images and facilities.
* Implemented corresponding service methods `getPropertyById` and `updateProperty` in `property.service.ts`, ensuring proper validation, permission checks, and transactional updates for property, facilities, and pictures.
* Updated property routes in `property.route.ts` to expose new GET and PUT endpoints for fetching and updating a property by ID, with authentication, authorization, and file upload support.

### Validation and Schema Updates

* Added `updatePropertyInputSchema` and `UpdatePropertyInput` type to `property.schema.ts` for validating property update requests.

### UI Improvements

* Improved the `Card` component’s layout by increasing vertical spacing and padding for better visual clarity.
* Enhanced the `LocationPicker` component to safely handle Google Maps marker animation, preventing errors in server-side rendering, and cleaned up the UI by removing redundant instructional text. 