### PR TITLE
refactor(api,web): switch property routes to /id/:id and modularize edit form

### DIFF
--- a/apps/api/src/routers/property.route.ts
+++ b/apps/api/src/routers/property.route.ts
@@ -24,25 +24,26 @@ router.get(
   propertyController.getPropertiesByTenant
 );
 
-router.get("/:slug", propertyController.getProperty);
 router.get(
-  "/:id",
+  "/id/:id",
   verifyTokenMiddleware,
   verifyRoleMiddleware,
   propertyController.getPropertyById
 );
 router.put(
-  "/:id",
+  "/id/:id",
   verifyTokenMiddleware,
   verifyRoleMiddleware,
   upload.fields([{ name: "propertyImages", maxCount: 10 }]),
   propertyController.updateProperty
 );
 router.delete(
-  "/:propertyId",
+  "/id/:propertyId",
   verifyTokenMiddleware,
   verifyRoleMiddleware,
   propertyController.deleteProperty
 );
+
+router.get("/:slug", propertyController.getProperty);
 
 export default router;

--- a/apps/web/src/components/tenant/edit-property-form.tsx
+++ b/apps/web/src/components/tenant/edit-property-form.tsx
@@ -1,241 +1,33 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { LocationPicker } from "@/components/ui/location-picker";
-import { Label } from "@/components/ui/label";
-import { Save, MapPin, Users, Building2, Camera } from "lucide-react";
-import { api } from "@/lib/axios";
-import { useSession } from "next-auth/react";
-import { toast } from "sonner";
-import Image from "next/image";
-import type { PropertyResponse } from "@repo/schemas";
-
-type Property = PropertyResponse & {
-  Pictures?: Array<{ id: string; imageUrl: string; note?: string | null }>;
-  Facilities?: Array<{ id: string; facility: string; note?: string | null }>;
-};
+import { Save } from "lucide-react";
+import { BasicInfoCard } from "./edit-property-form/basic-info-card";
+import { LocationCard } from "./edit-property-form/location-card";
+import { ImagesCard } from "./edit-property-form/images-card";
+import { useEditProperty } from "./edit-property-form/use-edit-property";
 
 interface EditPropertyFormProps {
   propertyId: string;
 }
 
 export function EditPropertyForm({ propertyId }: EditPropertyFormProps) {
-  const { data: session } = useSession();
-  const [property, setProperty] = useState<Property | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [selectedImages, setSelectedImages] = useState<File[]>([]);
-  const [selectedImagePreviews, setSelectedImagePreviews] = useState<string[]>(
-    []
-  );
-  const hiddenFileInput = useRef<HTMLInputElement | null>(null);
-
-  const [formData, setFormData] = useState({
-    name: "",
-    description: "",
-    country: "",
-    city: "",
-    address: "",
-    maxGuests: 1,
-    latitude: "",
-    longitude: "",
-  });
-
-  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
-
-  const handleLocationSelect = (location: {
-    lat: number;
-    lng: number;
-    address: string;
-    city: string;
-    country: string;
-  }) => {
-    setFormData((prev) => ({
-      ...prev,
-      latitude: location.lat.toString(),
-      longitude: location.lng.toString(),
-      address: location.address || prev.address,
-      city: location.city || prev.city,
-      country: location.country || prev.country,
-    }));
-  };
-
-  // Fetch property data
-  useEffect(() => {
-    const fetchProperty = async () => {
-      try {
-        setLoading(true);
-        const response = await api.get(`/properties/${propertyId}`, {
-          headers: {
-            Authorization: `Bearer ${session?.user?.accessToken}`,
-          },
-        });
-
-        const propertyData = response.data.data;
-        setProperty(propertyData);
-        setFormData({
-          name: propertyData.name || "",
-          description: propertyData.description || "",
-          country: propertyData.country || "",
-          city: propertyData.city || "",
-          address: propertyData.address || "",
-          maxGuests: propertyData.maxGuests || 1,
-          latitude: propertyData.latitude?.toString() || "",
-          longitude: propertyData.longitude?.toString() || "",
-        });
-      } catch (error: unknown) {
-        console.error("Error fetching property:", error);
-        const errorMessage =
-          error && typeof error === "object" && "response" in error
-            ? (error as { response?: { data?: { message?: string } } }).response
-                ?.data?.message
-            : "Failed to update property";
-        toast.error(errorMessage);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    if (session?.user?.accessToken && propertyId) {
-      fetchProperty();
-    }
-  }, [propertyId, session?.user?.accessToken]);
-
-  useEffect(() => {
-    if (selectedImages.length === 0) {
-      setSelectedImagePreviews([]);
-      return;
-    }
-
-    const previews = selectedImages.map((file) => URL.createObjectURL(file));
-    setSelectedImagePreviews(previews);
-
-    return () => {
-      previews.forEach((url) => URL.revokeObjectURL(url));
-    };
-  }, [selectedImages]);
-
-  const removeExistingPicture = (id: string) => {
-    setProperty((prev: Property | null) => {
-      if (!prev) return prev;
-      const updatedPictures = (prev.Pictures || []).filter(
-        (p: { id: string }) => p.id !== id
-      );
-      return {
-        ...prev,
-        Pictures: updatedPictures,
-      } as Property;
-    });
-  };
-
-  const removeSelectedImage = (index: number) => {
-    setSelectedImagePreviews((prev) => {
-      const url = prev[index];
-      if (url) URL.revokeObjectURL(url);
-      return prev.filter((_, i) => i !== index);
-    });
-
-    setSelectedImages((prev) => prev.filter((_, i) => i !== index));
-  };
-
-  const handleInputChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({
-      ...prev,
-      [name]: name === "maxGuests" ? parseInt(value) || 1 : value,
-    }));
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!session?.user?.accessToken) {
-      toast.error("Please login to continue");
-      return;
-    }
-
-    setIsSubmitting(true);
-
-    try {
-      const formDataToSend = new FormData();
-      formDataToSend.append("name", formData.name);
-      formDataToSend.append("description", formData.description);
-      formDataToSend.append("country", formData.country);
-      formDataToSend.append("city", formData.city);
-      formDataToSend.append("address", formData.address);
-      formDataToSend.append("maxGuests", formData.maxGuests.toString());
-
-      if (formData.latitude) {
-        formDataToSend.append("latitude", formData.latitude);
-      }
-      if (formData.longitude) {
-        formDataToSend.append("longitude", formData.longitude);
-      }
-
-      if (property?.Pictures) {
-        formDataToSend.append(
-          "existingPictures",
-          JSON.stringify(
-            property.Pictures.map(
-              (pic: {
-                id: string;
-                imageUrl: string;
-                note?: string | null;
-              }) => ({
-                id: pic.id,
-                imageUrl: pic.imageUrl,
-                note: pic.note ?? null,
-              })
-            )
-          )
-        );
-      }
-
-      selectedImages.forEach((image) => {
-        formDataToSend.append("propertyImages", image);
-      });
-
-      if (selectedImages.length > 0) {
-        const picturesData = selectedImages.map((_, index) => ({
-          fileIndex: index,
-          note: null,
-        }));
-        formDataToSend.append("propertyPictures", JSON.stringify(picturesData));
-      }
-
-      const response = await api.put(
-        `/properties/${propertyId}`,
-        formDataToSend,
-        {
-          headers: {
-            Authorization: `Bearer ${session.user.accessToken}`,
-            "Content-Type": "multipart/form-data",
-          },
-        }
-      );
-
-      toast.success("Property updated successfully!");
-
-      // Refresh property data
-      const updatedProperty = response.data.data;
-      setProperty(updatedProperty);
-      setSelectedImages([]);
-    } catch (error: unknown) {
-      console.error("Error updating property:", error);
-      const errorMessage =
-        error && typeof error === "object" && "response" in error
-          ? (error as { response?: { data?: { message?: string } } }).response
-              ?.data?.message
-          : "Failed to update property";
-      toast.error(errorMessage);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+  const {
+    property,
+    loading,
+    isSubmitting,
+    formData,
+    selectedImages,
+    selectedImagePreviews,
+    hiddenFileInput,
+    apiKey,
+    handleInputChange,
+    handleLocationSelect,
+    setSelectedImages,
+    removeExistingPicture,
+    removeSelectedImage,
+    handleSubmit,
+  } = useEditProperty(propertyId);
 
   if (loading) {
     return (
@@ -278,340 +70,38 @@ export function EditPropertyForm({ propertyId }: EditPropertyFormProps) {
         className="space-y-6"
       >
         <div className="grid gap-6 lg:grid-cols-2">
-          {/* Basic Information */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Building2 className="h-5 w-5" />
-                Basic Information
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="name">Property Name</Label>
-                <Input
-                  id="name"
-                  name="name"
-                  value={formData.name}
-                  onChange={handleInputChange}
-                  placeholder="Enter property name"
-                  maxLength={100}
-                  required
-                />
-              </div>
+          <BasicInfoCard
+            values={{
+              name: formData.name,
+              description: formData.description,
+              maxGuests: formData.maxGuests,
+            }}
+            onChange={handleInputChange}
+          />
 
-              <div className="space-y-2">
-                <Label htmlFor="description">Description</Label>
-                <textarea
-                  id="description"
-                  name="description"
-                  value={formData.description}
-                  onChange={handleInputChange}
-                  placeholder="Describe your property..."
-                  className="flex min-h-[100px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
-                  required
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="maxGuests">Maximum Guests</Label>
-                <Input
-                  id="maxGuests"
-                  name="maxGuests"
-                  type="number"
-                  min="1"
-                  value={formData.maxGuests}
-                  onChange={handleInputChange}
-                  required
-                />
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Location Information */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <MapPin className="h-5 w-5" />
-                Location
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {apiKey && (
-                <div className="space-y-4">
-                  <div>
-                    <LocationPicker
-                      onLocationSelect={handleLocationSelect}
-                      apiKey={apiKey}
-                      initialLocation={
-                        formData.latitude && formData.longitude
-                          ? {
-                              lat: parseFloat(formData.latitude),
-                              lng: parseFloat(formData.longitude),
-                            }
-                          : undefined
-                      }
-                      className="border rounded-lg p-4"
-                    />
-                  </div>
-                </div>
-              )}
-
-              <div className="grid grid-cols-2 gap-4">
-                {" "}
-                <div className="space-y-2">
-                  <Label htmlFor="country">Country</Label>
-                  <Input
-                    id="country"
-                    name="country"
-                    value={formData.country}
-                    onChange={handleInputChange}
-                    placeholder="Enter country"
-                    maxLength={60}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="city">City</Label>
-                  <Input
-                    id="city"
-                    name="city"
-                    value={formData.city}
-                    onChange={handleInputChange}
-                    placeholder="Enter city"
-                    maxLength={100}
-                    required
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="address">Address</Label>
-                <Input
-                  id="address"
-                  name="address"
-                  value={formData.address}
-                  onChange={handleInputChange}
-                  placeholder="Enter full address"
-                  required
-                />
-              </div>
-            </CardContent>
-          </Card>
+          <LocationCard
+            apiKey={apiKey}
+            values={{
+              country: formData.country,
+              city: formData.city,
+              address: formData.address,
+              latitude: formData.latitude,
+              longitude: formData.longitude,
+            }}
+            onChange={handleInputChange}
+            onLocationSelect={handleLocationSelect}
+          />
         </div>
 
-        {/* Property Images Section */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Camera className="h-5 w-5" />
-              Property Images
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              {/* Display existing images */}
-              {property.Pictures && property.Pictures.length > 0 && (
-                <div>
-                  <h4 className="text-sm font-medium mb-2">Current Images</h4>
-                  <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-h-64 overflow-y-auto py-1">
-                    {property.Pictures.map(
-                      (picture: {
-                        id: string;
-                        imageUrl: string;
-                        note?: string | null;
-                      }) => (
-                        <div
-                          key={picture.id}
-                          className="relative w-full h-40 overflow-hidden rounded-md"
-                        >
-                          <Image
-                            src={picture.imageUrl}
-                            alt="Property"
-                            width={320}
-                            height={200}
-                            className="w-full h-full object-cover rounded-md"
-                          />
-
-                          {/* Remove existing picture button */}
-                          <button
-                            type="button"
-                            onClick={() => removeExistingPicture(picture.id)}
-                            className="absolute top-2 right-2 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-sm text-red-600 hover:bg-white"
-                            aria-label="Remove image"
-                          >
-                            ×
-                          </button>
-
-                          {picture.note && (
-                            <p className="text-xs text-muted-foreground mt-1 truncate">
-                              {picture.note}
-                            </p>
-                          )}
-                        </div>
-                      )
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* File upload for new images */}
-              <div>
-                <Label htmlFor="images">Add New Images</Label>
-                {/* Hidden actual file input */}
-                <input
-                  id="images-hidden"
-                  ref={hiddenFileInput}
-                  type="file"
-                  multiple
-                  accept="image/*"
-                  onChange={(e) => {
-                    const files = Array.from(e.target.files || []);
-                    setSelectedImages((prev) => [...prev, ...files]);
-                  }}
-                  className="hidden"
-                />
-
-                {/* Visible button that summarizes selected filenames and triggers hidden input */}
-                <button
-                  type="button"
-                  onClick={() => hiddenFileInput.current?.click()}
-                  className="mt-1 w-full rounded-md border border-input px-3 py-2 text-left text-sm hover:bg-muted/50"
-                >
-                  {selectedImages.length === 0 ? (
-                    <span className="text-muted-foreground">
-                      Click to select images
-                    </span>
-                  ) : (
-                    <span>
-                      {selectedImages
-                        .slice(0, 3)
-                        .map((f) => f.name)
-                        .join(", ")}
-                      {selectedImages.length > 3 && (
-                        <span className="ml-2 text-muted-foreground">
-                          +{selectedImages.length - 3} more
-                        </span>
-                      )}
-                    </span>
-                  )}
-                </button>
-                {selectedImages.length > 0 && (
-                  <div className="mt-2">
-                    <p className="text-sm text-muted-foreground">
-                      {selectedImages.length} new image(s) selected
-                    </p>
-
-                    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-h-64 overflow-y-auto py-1 mt-2">
-                      {selectedImagePreviews.map((src, idx) => (
-                        <div
-                          key={idx}
-                          className="relative w-full h-40 overflow-hidden rounded-md"
-                        >
-                          <Image
-                            src={src}
-                            alt={`preview-${idx}`}
-                            width={320}
-                            height={200}
-                            className="w-full h-full object-cover rounded-md"
-                          />
-
-                          <button
-                            type="button"
-                            onClick={() => removeSelectedImage(idx)}
-                            className="absolute top-2 right-2 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-sm text-red-600 hover:bg-white"
-                            aria-label="Remove selected image"
-                          >
-                            ×
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Additional Management Links */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Building2 className="h-5 w-5" />
-              Additional Management
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-              <Button
-                variant="outline"
-                className="h-auto p-4 flex flex-col items-center gap-2"
-                asChild
-              >
-                <a href={`/dashboard/tenant/properties/${propertyId}/rooms`}>
-                  <Users className="h-6 w-6" />
-                  <div className="text-center">
-                    <div className="font-medium">Room Management</div>
-                    <div className="text-xs text-muted-foreground">
-                      Manage rooms
-                    </div>
-                  </div>
-                </a>
-              </Button>
-
-              <Button
-                variant="outline"
-                className="h-auto p-4 flex flex-col items-center gap-2"
-                asChild
-              >
-                <a
-                  href={`/dashboard/tenant/properties/${propertyId}/availability`}
-                >
-                  <Users className="h-6 w-6" />
-                  <div className="text-center">
-                    <div className="font-medium">Availability</div>
-                    <div className="text-xs text-muted-foreground">
-                      Manage availability
-                    </div>
-                  </div>
-                </a>
-              </Button>
-
-              <Button
-                variant="outline"
-                className="h-auto p-4 flex flex-col items-center gap-2"
-                asChild
-              >
-                <a href={`/dashboard/tenant/properties/${propertyId}/category`}>
-                  <Users className="h-6 w-6" />
-                  <div className="text-center">
-                    <div className="font-medium">Categories</div>
-                    <div className="text-xs text-muted-foreground">
-                      Manage categories
-                    </div>
-                  </div>
-                </a>
-              </Button>
-
-              <Button
-                variant="outline"
-                className="h-auto p-4 flex flex-col items-center gap-2"
-                asChild
-              >
-                <a href={`/dashboard/tenant/properties/${propertyId}/pricing`}>
-                  <Users className="h-6 w-6" />
-                  <div className="text-center">
-                    <div className="font-medium">Pricing</div>
-                    <div className="text-xs text-muted-foreground">
-                      Adjust pricing
-                    </div>
-                  </div>
-                </a>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+        <ImagesCard
+          existingPictures={property.Pictures}
+          onRemoveExisting={removeExistingPicture}
+          selectedImages={selectedImages}
+          setSelectedImages={setSelectedImages}
+          selectedImagePreviews={selectedImagePreviews}
+          onRemoveSelected={removeSelectedImage}
+          hiddenFileInput={hiddenFileInput}
+        />
       </form>
     </div>
   );

--- a/apps/web/src/components/tenant/edit-property-form/basic-info-card.tsx
+++ b/apps/web/src/components/tenant/edit-property-form/basic-info-card.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Building2 } from "lucide-react";
+import React from "react";
+
+type Props = {
+  values: {
+    name: string;
+    description: string;
+    maxGuests: number;
+  };
+  onChange: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void;
+};
+
+export function BasicInfoCard({ values, onChange }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Building2 className="h-5 w-5" />
+          Basic Information
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="name">Property Name</Label>
+          <Input
+            id="name"
+            name="name"
+            value={values.name}
+            onChange={onChange}
+            placeholder="Enter property name"
+            maxLength={100}
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="description">Description</Label>
+          <textarea
+            id="description"
+            name="description"
+            value={values.description}
+            onChange={onChange}
+            placeholder="Describe your property..."
+            className="flex min-h-[100px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="maxGuests">Maximum Guests</Label>
+          <Input
+            id="maxGuests"
+            name="maxGuests"
+            type="number"
+            min="1"
+            value={values.maxGuests}
+            onChange={onChange}
+            required
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/tenant/edit-property-form/images-card.tsx
+++ b/apps/web/src/components/tenant/edit-property-form/images-card.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Camera } from "lucide-react";
+import Image from "next/image";
+import React from "react";
+
+type ExistingPicture = { id: string; imageUrl: string; note?: string | null };
+
+type Props = {
+  existingPictures?: ExistingPicture[];
+  onRemoveExisting: (id: string) => void;
+  selectedImages: File[];
+  setSelectedImages: React.Dispatch<React.SetStateAction<File[]>>;
+  selectedImagePreviews: string[];
+  onRemoveSelected: (index: number) => void;
+  hiddenFileInput: React.RefObject<HTMLInputElement | null>;
+};
+
+export function ImagesCard({
+  existingPictures,
+  onRemoveExisting,
+  selectedImages,
+  setSelectedImages,
+  selectedImagePreviews,
+  onRemoveSelected,
+  hiddenFileInput,
+}: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Camera className="h-5 w-5" />
+          Property Images
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {existingPictures && existingPictures.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium mb-2">Current Images</h4>
+              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-h-64 overflow-y-auto py-1">
+                {existingPictures.map((picture) => (
+                  <div
+                    key={picture.id}
+                    className="relative w-full h-40 overflow-hidden rounded-md"
+                  >
+                    <Image
+                      src={picture.imageUrl}
+                      alt="Property"
+                      width={320}
+                      height={200}
+                      className="w-full h-full object-cover rounded-md"
+                    />
+
+                    <button
+                      type="button"
+                      onClick={() => onRemoveExisting(picture.id)}
+                      className="absolute top-2 right-2 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-sm text-red-600 hover:bg-white"
+                      aria-label="Remove image"
+                    >
+                      ×
+                    </button>
+
+                    {picture.note && (
+                      <p className="text-xs text-muted-foreground mt-1 truncate">
+                        {picture.note}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <Label htmlFor="images">Add New Images</Label>
+            <input
+              id="images-hidden"
+              ref={hiddenFileInput}
+              type="file"
+              multiple
+              accept="image/*"
+              onChange={(e) => {
+                const files = Array.from(e.target.files || []);
+                setSelectedImages((prev) => [...prev, ...files]);
+              }}
+              className="hidden"
+            />
+
+            <button
+              type="button"
+              onClick={() => hiddenFileInput.current?.click()}
+              className="mt-1 w-full rounded-md border border-input px-3 py-2 text-left text-sm hover:bg-muted/50"
+            >
+              {selectedImages.length === 0 ? (
+                <span className="text-muted-foreground">
+                  Click to select images
+                </span>
+              ) : (
+                <span>
+                  {selectedImages
+                    .slice(0, 3)
+                    .map((f) => f.name)
+                    .join(", ")}
+                  {selectedImages.length > 3 && (
+                    <span className="ml-2 text-muted-foreground">
+                      +{selectedImages.length - 3} more
+                    </span>
+                  )}
+                </span>
+              )}
+            </button>
+
+            {selectedImages.length > 0 && (
+              <div className="mt-2">
+                <p className="text-sm text-muted-foreground">
+                  {selectedImages.length} new image(s) selected
+                </p>
+
+                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-h-64 overflow-y-auto py-1 mt-2">
+                  {selectedImagePreviews.map((src, idx) => (
+                    <div
+                      key={idx}
+                      className="relative w-full h-40 overflow-hidden rounded-md"
+                    >
+                      <Image
+                        src={src}
+                        alt={`preview-${idx}`}
+                        width={320}
+                        height={200}
+                        className="w-full h-full object-cover rounded-md"
+                      />
+
+                      <button
+                        type="button"
+                        onClick={() => onRemoveSelected(idx)}
+                        className="absolute top-2 right-2 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-sm text-red-600 hover:bg-white"
+                        aria-label="Remove selected image"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/tenant/edit-property-form/images-card.tsx
+++ b/apps/web/src/components/tenant/edit-property-form/images-card.tsx
@@ -2,7 +2,9 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
-import { Camera } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Camera, X } from "lucide-react";
 import Image from "next/image";
 import React from "react";
 
@@ -40,7 +42,7 @@ export function ImagesCard({
           {existingPictures && existingPictures.length > 0 && (
             <div>
               <h4 className="text-sm font-medium mb-2">Current Images</h4>
-              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-h-64 overflow-y-auto py-1">
+              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 py-1">
                 {existingPictures.map((picture) => (
                   <div
                     key={picture.id}
@@ -57,10 +59,10 @@ export function ImagesCard({
                     <button
                       type="button"
                       onClick={() => onRemoveExisting(picture.id)}
-                      className="absolute top-2 right-2 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-sm text-red-600 hover:bg-white"
+                      className="absolute top-2 right-2 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-sm text-red-600 hover:bg-white cursor-pointer"
                       aria-label="Remove image"
                     >
-                      ×
+                      <X className="h-3 w-3" />
                     </button>
 
                     {picture.note && (
@@ -74,7 +76,11 @@ export function ImagesCard({
             </div>
           )}
 
-          <div>
+          <div className="my-4">
+            <Separator />
+          </div>
+
+          <div className="space-y-4">
             <Label htmlFor="images">Add New Images</Label>
             <input
               id="images-hidden"
@@ -89,29 +95,33 @@ export function ImagesCard({
               className="hidden"
             />
 
-            <button
-              type="button"
-              onClick={() => hiddenFileInput.current?.click()}
-              className="mt-1 w-full rounded-md border border-input px-3 py-2 text-left text-sm hover:bg-muted/50"
-            >
-              {selectedImages.length === 0 ? (
-                <span className="text-muted-foreground">
-                  Click to select images
-                </span>
-              ) : (
-                <span>
-                  {selectedImages
-                    .slice(0, 3)
-                    .map((f) => f.name)
-                    .join(", ")}
-                  {selectedImages.length > 3 && (
-                    <span className="ml-2 text-muted-foreground">
-                      +{selectedImages.length - 3} more
-                    </span>
-                  )}
-                </span>
-              )}
-            </button>
+            <div className="mt-1 flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => hiddenFileInput.current?.click()}
+              >
+                Choose Files
+              </Button>
+
+              <div className="text-sm text-muted-foreground">
+                {selectedImages.length === 0 ? (
+                  "No files selected"
+                ) : (
+                  <span title={selectedImages.map((f) => f.name).join(", ")}>
+                    {selectedImages
+                      .slice(0, 3)
+                      .map((f) => f.name)
+                      .join(", ")}
+                    {selectedImages.length > 3 && (
+                      <span className="ml-2 text-muted-foreground">
+                        +{selectedImages.length - 3} more
+                      </span>
+                    )}
+                  </span>
+                )}
+              </div>
+            </div>
 
             {selectedImages.length > 0 && (
               <div className="mt-2">
@@ -119,11 +129,18 @@ export function ImagesCard({
                   {selectedImages.length} new image(s) selected
                 </p>
 
-                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-h-64 overflow-y-auto py-1 mt-2">
+                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 py-1 mt-2">
                   {selectedImagePreviews.map((src, idx) => (
                     <div
                       key={idx}
-                      className="relative w-full h-40 overflow-hidden rounded-md"
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => hiddenFileInput.current?.click()}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ")
+                          hiddenFileInput.current?.click();
+                      }}
+                      className="relative w-full h-40 overflow-hidden rounded-md cursor-pointer"
                     >
                       <Image
                         src={src}
@@ -135,11 +152,14 @@ export function ImagesCard({
 
                       <button
                         type="button"
-                        onClick={() => onRemoveSelected(idx)}
-                        className="absolute top-2 right-2 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-sm text-red-600 hover:bg-white"
+                        onClick={(ev) => {
+                          ev.stopPropagation();
+                          onRemoveSelected(idx);
+                        }}
+                        className="absolute top-2 right-2 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-sm text-red-600 hover:bg-white cursor-pointer"
                         aria-label="Remove selected image"
                       >
-                        ×
+                        <X className="h-3 w-3" />
                       </button>
                     </div>
                   ))}

--- a/apps/web/src/components/tenant/edit-property-form/location-card.tsx
+++ b/apps/web/src/components/tenant/edit-property-form/location-card.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LocationPicker } from "@/components/ui/location-picker";
+import { MapPin } from "lucide-react";
+import React from "react";
+
+type Props = {
+  apiKey?: string;
+  values: {
+    country: string;
+    city: string;
+    address: string;
+    latitude: string;
+    longitude: string;
+  };
+  onChange: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void;
+  onLocationSelect: (loc: {
+    lat: number;
+    lng: number;
+    address: string;
+    city: string;
+    country: string;
+  }) => void;
+};
+
+export function LocationCard({
+  apiKey,
+  values,
+  onChange,
+  onLocationSelect,
+}: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <MapPin className="h-5 w-5" />
+          Location
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {apiKey && (
+          <div className="space-y-4">
+            <div>
+              <LocationPicker
+                onLocationSelect={onLocationSelect}
+                apiKey={apiKey}
+                initialLocation={
+                  values.latitude && values.longitude
+                    ? {
+                        lat: parseFloat(values.latitude),
+                        lng: parseFloat(values.longitude),
+                      }
+                    : undefined
+                }
+                className="border rounded-lg p-4"
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="country">Country</Label>
+            <Input
+              id="country"
+              name="country"
+              value={values.country}
+              onChange={onChange}
+              placeholder="Enter country"
+              maxLength={60}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="city">City</Label>
+            <Input
+              id="city"
+              name="city"
+              value={values.city}
+              onChange={onChange}
+              placeholder="Enter city"
+              maxLength={100}
+              required
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="address">Address</Label>
+          <Input
+            id="address"
+            name="address"
+            value={values.address}
+            onChange={onChange}
+            placeholder="Enter full address"
+            required
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/tenant/edit-property-form/types.ts
+++ b/apps/web/src/components/tenant/edit-property-form/types.ts
@@ -1,0 +1,25 @@
+import type { PropertyResponse } from "@repo/schemas";
+
+export type Property = PropertyResponse & {
+  Pictures?: Array<{ id: string; imageUrl: string; note?: string | null }>;
+  Facilities?: Array<{ id: string; facility: string; note?: string | null }>;
+};
+
+export type LocationValue = {
+  lat: number;
+  lng: number;
+  address: string;
+  city: string;
+  country: string;
+};
+
+export type EditPropertyFormData = {
+  name: string;
+  description: string;
+  country: string;
+  city: string;
+  address: string;
+  maxGuests: number;
+  latitude: string;
+  longitude: string;
+};

--- a/apps/web/src/components/tenant/edit-property-form/use-edit-property.ts
+++ b/apps/web/src/components/tenant/edit-property-form/use-edit-property.ts
@@ -1,0 +1,225 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useSession } from "next-auth/react";
+import { toast } from "sonner";
+import { api } from "@/lib/axios";
+
+import type { Property, LocationValue, EditPropertyFormData } from "./types";
+
+export function useEditProperty(propertyId: string) {
+  const { data: session } = useSession();
+
+  const [property, setProperty] = useState<Property | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [selectedImages, setSelectedImages] = useState<File[]>([]);
+  const [selectedImagePreviews, setSelectedImagePreviews] = useState<string[]>(
+    []
+  );
+  const hiddenFileInput = useRef<HTMLInputElement | null>(null);
+
+  const [formData, setFormData] = useState<EditPropertyFormData>({
+    name: "",
+    description: "",
+    country: "",
+    city: "",
+    address: "",
+    maxGuests: 1,
+    latitude: "",
+    longitude: "",
+  });
+
+  const apiKey = useMemo(() => process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY, []);
+
+  const handleLocationSelect = (location: LocationValue) => {
+    setFormData((prev) => ({
+      ...prev,
+      latitude: location.lat.toString(),
+      longitude: location.lng.toString(),
+      address: location.address || prev.address,
+      city: location.city || prev.city,
+      country: location.country || prev.country,
+    }));
+  };
+
+  useEffect(() => {
+    const fetchProperty = async () => {
+      try {
+        setLoading(true);
+        const response = await api.get(`/properties/id/${propertyId}`, {
+          headers: {
+            Authorization: `Bearer ${session?.user?.accessToken}`,
+          },
+        });
+
+        const propertyData = response.data.data as Property;
+        setProperty(propertyData);
+        setFormData({
+          name: propertyData.name || "",
+          description: propertyData.description || "",
+          country: propertyData.country || "",
+          city: propertyData.city || "",
+          address: propertyData.address || "",
+          maxGuests: propertyData.maxGuests || 1,
+          latitude: propertyData.latitude?.toString() || "",
+          longitude: propertyData.longitude?.toString() || "",
+        });
+      } catch (error: unknown) {
+        console.error("Error fetching property:", error);
+        const errorMessage =
+          error && typeof error === "object" && "response" in error
+            ? (error as { response?: { data?: { message?: string } } }).response
+                ?.data?.message
+            : "Failed to update property";
+        toast.error(errorMessage);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (session?.user?.accessToken && propertyId) {
+      fetchProperty();
+    }
+  }, [propertyId, session?.user?.accessToken]);
+
+  useEffect(() => {
+    if (selectedImages.length === 0) {
+      setSelectedImagePreviews([]);
+      return;
+    }
+    const previews = selectedImages.map((file) => URL.createObjectURL(file));
+    setSelectedImagePreviews(previews);
+    return () => {
+      previews.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, [selectedImages]);
+
+  const removeExistingPicture = (id: string) => {
+    setProperty((prev: Property | null) => {
+      if (!prev) return prev;
+      const updatedPictures = (prev.Pictures || []).filter(
+        (p: { id: string }) => p.id !== id
+      );
+      return { ...prev, Pictures: updatedPictures } as Property;
+    });
+  };
+
+  const removeSelectedImage = (index: number) => {
+    setSelectedImagePreviews((prev) => {
+      const url = prev[index];
+      if (url) URL.revokeObjectURL(url);
+      return prev.filter((_, i) => i !== index);
+    });
+    setSelectedImages((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: name === "maxGuests" ? parseInt(value) || 1 : value,
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!session?.user?.accessToken) {
+      toast.error("Please login to continue");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const formDataToSend = new FormData();
+      formDataToSend.append("name", formData.name);
+      formDataToSend.append("description", formData.description);
+      formDataToSend.append("country", formData.country);
+      formDataToSend.append("city", formData.city);
+      formDataToSend.append("address", formData.address);
+      formDataToSend.append("maxGuests", formData.maxGuests.toString());
+      if (formData.latitude)
+        formDataToSend.append("latitude", formData.latitude);
+      if (formData.longitude)
+        formDataToSend.append("longitude", formData.longitude);
+
+      if (property?.Pictures) {
+        formDataToSend.append(
+          "existingPictures",
+          JSON.stringify(
+            property.Pictures.map(
+              (pic: {
+                id: string;
+                imageUrl: string;
+                note?: string | null;
+              }) => ({
+                id: pic.id,
+                imageUrl: pic.imageUrl,
+                note: pic.note ?? null,
+              })
+            )
+          )
+        );
+      }
+
+      selectedImages.forEach((image) => {
+        formDataToSend.append("propertyImages", image);
+      });
+
+      if (selectedImages.length > 0) {
+        const picturesData = selectedImages.map((_, index) => ({
+          fileIndex: index,
+          note: null as string | null,
+        }));
+        formDataToSend.append("propertyPictures", JSON.stringify(picturesData));
+      }
+
+      const response = await api.put(
+        `/properties/id/${propertyId}`,
+        formDataToSend,
+        {
+          headers: {
+            Authorization: `Bearer ${session.user.accessToken}`,
+            "Content-Type": "multipart/form-data",
+          },
+        }
+      );
+
+      toast.success("Property updated successfully!");
+      const updatedProperty = response.data.data as Property;
+      setProperty(updatedProperty);
+      setSelectedImages([]);
+    } catch (error: unknown) {
+      console.error("Error updating property:", error);
+      const errorMessage =
+        error && typeof error === "object" && "response" in error
+          ? (error as { response?: { data?: { message?: string } } }).response
+              ?.data?.message
+          : "Failed to update property";
+      toast.error(errorMessage);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    property,
+    loading,
+    isSubmitting,
+    formData,
+    selectedImages,
+    selectedImagePreviews,
+    hiddenFileInput,
+    apiKey,
+    setFormData,
+    handleInputChange,
+    handleLocationSelect,
+    setSelectedImages,
+    removeExistingPicture,
+    removeSelectedImage,
+    handleSubmit,
+  } as const;
+}

--- a/apps/web/src/hooks/useTenantProperties.ts
+++ b/apps/web/src/hooks/useTenantProperties.ts
@@ -57,7 +57,7 @@ export function useTenantProperties(tenantId: string) {
 
       try {
         const api = createApiInstance(session.user.accessToken);
-        await api.delete(`/properties/${propertyId}`);
+        await api.delete(`/properties/id/${propertyId}`);
         setProperties((props) => props.filter((p) => p.id !== propertyId));
         toast.success("Property deleted successfully");
       } catch (err) {


### PR DESCRIPTION

### API route updates

* Standardized property API endpoints to use the `/id/:id` pattern for fetching, updating, and deleting properties, replacing the previous `/:id` and `/:propertyId` routes. This improves clarity and consistency for property identification. 
* Updated frontend API calls to match the new `/id/:propertyId` endpoint for property deletion, ensuring compatibility with backend changes.

### Edit property form modularization

* Added new reusable components for property editing: `BasicInfoCard`, `LocationCard`, and `ImagesCard`, each handling a specific section of the property form (basic info, location, and images respectively). These components improve code organization and user experience.
* Introduced a custom hook `useEditProperty` to manage form state, image selection and preview, API communication, and form submission logic for property editing. This centralizes and simplifies complex form logic. 
* Defined shared TypeScript types (`Property`, `LocationValue`, `EditPropertyFormData`) to standardize data structures across components and API interactions, reducing errors and improving maintainability.