### PR TITLE
feat(auth+rooms): sync session token to axios; migrate useRooms to react-query; add 1MB image limit

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@tanstack/react-query-devtools": "^5.89.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/apps/web/src/components/providers/auth-provider.tsx
+++ b/apps/web/src/components/providers/auth-provider.tsx
@@ -1,10 +1,26 @@
 "use client";
 
-import { SessionProvider } from "next-auth/react";
-import { ReactNode } from "react";
+import { SessionProvider, useSession } from "next-auth/react";
+import { ReactNode, useEffect } from "react";
+import { setAuthToken } from "@/lib/axios";
+
+function SessionTokenSync({ children }: { children: ReactNode }) {
+  const { data: session } = useSession();
+
+  useEffect(() => {
+    const token = session?.user?.accessToken ?? null;
+    setAuthToken(token);
+  }, [session]);
+
+  return <>{children}</>;
+}
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <SessionTokenSync>{children}</SessionTokenSync>
+    </SessionProvider>
+  );
 }
 
 export default AuthProvider;

--- a/apps/web/src/components/providers/query-provider.tsx
+++ b/apps/web/src/components/providers/query-provider.tsx
@@ -19,8 +19,32 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
       })
   );
 
+  const [Devtools, setDevtools] = React.useState<React.ComponentType<{
+    initialIsOpen?: boolean;
+  }> | null>(null);
+
+  React.useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+
+    let mounted = true;
+    import("@tanstack/react-query-devtools")
+      .then((mod) => {
+        if (mounted && mod && mod.ReactQueryDevtools) {
+          setDevtools(() => mod.ReactQueryDevtools);
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {Devtools ? <Devtools initialIsOpen={false} /> : null}
+    </QueryClientProvider>
   );
 }
 

--- a/apps/web/src/components/tenant/room-form/image-field.tsx
+++ b/apps/web/src/components/tenant/room-form/image-field.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 import type { RoomFormErrors } from "./types";
 import type { RefObject } from "react";
 
@@ -28,6 +29,24 @@ export function ImageField({
   truncateFileName,
   errors,
 }: Props) {
+  const MAX_FILE_SIZE = 1 * 1024 * 1024;
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0] ?? null;
+    if (!file) {
+      onFileChange(e);
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      toast.error("Image must be 1MB or smaller");
+      if (fileInputRef?.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    onFileChange(e);
+  }
+
   return (
     <div className="space-y-2">
       <input
@@ -35,8 +54,8 @@ export function ImageField({
         id="imageFile"
         name="imageFile"
         type="file"
-        accept="image/*"
-        onChange={onFileChange}
+        accept=".png,.jpg,.jpeg"
+        onChange={handleFileChange}
         disabled={isSubmitting}
         className="hidden"
       />
@@ -89,7 +108,9 @@ export function ImageField({
         ) : (
           <div className="flex flex-col items-center gap-1 text-sm text-muted-foreground">
             <div>Click an image here to upload</div>
-            <div className="text-xs text-muted-foreground">PNG, JPG, GIF</div>
+            <div className="text-xs text-muted-foreground">
+              PNG, JPG — max 1MB
+            </div>
           </div>
         )}
       </div>

--- a/apps/web/src/lib/axios.ts
+++ b/apps/web/src/lib/axios.ts
@@ -15,10 +15,6 @@ export function setAuthToken(token: string | null) {
   authToken = token;
 }
 
-export function getAuthToken() {
-  return authToken;
-}
-
 api.interceptors.request.use((config) => {
   const token = authToken;
   if (token) {

--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+export function getErrorMessage(
+  err: unknown,
+  fallback = "Something went wrong"
+) {
+  if (axios.isAxiosError(err) && err.response?.data?.message) {
+    return err.response.data.message as string;
+  }
+  return fallback;
+}
+
+export default getErrorMessage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,7 @@
             "devDependencies": {
                 "@eslint/eslintrc": "^3",
                 "@tailwindcss/postcss": "^4",
+                "@tanstack/react-query-devtools": "^5.89.0",
                 "@types/node": "^20",
                 "@types/react": "^19",
                 "@types/react-dom": "^19",
@@ -3248,6 +3249,17 @@
                 "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
+        "node_modules/@tanstack/query-devtools": {
+            "version": "5.87.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.87.3.tgz",
+            "integrity": "sha512-LkzxzSr2HS1ALHTgDmJH5eGAVsSQiuwz//VhFW5OqNk0OQ+Fsqba0Tsf+NzWRtXYvpgUqwQr4b2zdFZwxHcGvg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
         "node_modules/@tanstack/react-query": {
             "version": "5.89.0",
             "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.89.0.tgz",
@@ -3261,6 +3273,24 @@
                 "url": "https://github.com/sponsors/tannerlinsley"
             },
             "peerDependencies": {
+                "react": "^18 || ^19"
+            }
+        },
+        "node_modules/@tanstack/react-query-devtools": {
+            "version": "5.89.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.89.0.tgz",
+            "integrity": "sha512-Syc4UjZeIJCkXCRGyQcWwlnv89JNb98MMg/DAkFCV3rwOcknj98+nG3Nm6xLXM6ne9sK6RZeDJMPLKZUh6NUGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/query-devtools": "5.87.3"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "@tanstack/react-query": "^5.89.0",
                 "react": "^18 || ^19"
             }
         },


### PR DESCRIPTION
**Authentication and API Integration:**

* The `AuthProvider` now synchronizes the user's access token with the API client (`axios`) using a new `SessionTokenSync` component, ensuring that authenticated requests always use the latest token.

**Room Management Refactor:**

* The `useRooms` hook is refactored to use `react-query` for data fetching and mutations, replacing manual state management. This centralizes loading/error states and simplifies cache updates after create, update, and delete actions.
* Error handling in `useRooms` is standardized using a new utility function, `getErrorMessage`, which extracts meaningful messages from Axios errors.

**Form Validation Improvements:**

* The `ImageField` component now enforces a 1MB maximum file size for uploads and restricts accepted file types to PNG and JPG, with user feedback via toast notifications. 

**Developer Experience:**

* Adds `@tanstack/react-query-devtools` for improved debugging during development, loaded dynamically in the `QueryProvider` and excluded from production builds.

**Codebase Cleanup:**

* Removes the unused `getAuthToken` function from `axios.ts` to streamline the API client.