### PR TITLE
feat(property): remove inline category creation; require existing propertyCategoryId

### DIFF
--- a/apps/api/src/controllers/property.controller.ts
+++ b/apps/api/src/controllers/property.controller.ts
@@ -43,13 +43,10 @@ export class PropertyController {
           : undefined,
       };
 
-      if (request.body.propertyCategoryId) {
-        propertyData.propertyCategoryId = request.body.propertyCategoryId;
-      } else if (request.body.customCategoryId) {
-        propertyData.customCategoryId = request.body.customCategoryId;
-      } else if (request.body.customCategory) {
-        propertyData.customCategory = JSON.parse(request.body.customCategory);
-      }
+      propertyData.propertyCategoryId =
+        request.body.propertyCategoryId || undefined;
+      propertyData.customCategoryId =
+        request.body.customCategoryId || undefined;
 
       const facilities = request.body.facilities
         ? JSON.parse(request.body.facilities)
@@ -287,35 +284,24 @@ export class PropertyController {
       if (request.body.longitude)
         updateData.longitude = parseFloat(request.body.longitude);
 
-      // Category data
       if (request.body.propertyCategoryId) {
         updateData.propertyCategoryId = request.body.propertyCategoryId;
       } else if (request.body.customCategoryId) {
         updateData.customCategoryId = request.body.customCategoryId;
-      } else if (request.body.customCategory) {
-        updateData.customCategory = JSON.parse(request.body.customCategory);
       }
 
       // Facilities
       if (request.body.facilities) {
         updateData.facilities = JSON.parse(request.body.facilities);
       }
-
-      // Handle property images
-      // Strategy: keep any existing pictures provided by `existingPictures` and
-      // append newly uploaded files. Only remove pictures if the client sends
-      // an explicit list that omits them (client should send full desired list
-      // via `existingPictures`) or include a deletion mechanism in the future.
       const finalPictures: Array<{ imageUrl: string; note?: string | null }> =
         [];
 
-      // Start with existing pictures if provided
       if (request.body.existingPictures) {
         try {
           const existing = JSON.parse(request.body.existingPictures);
           if (Array.isArray(existing)) {
             for (const p of existing) {
-              // Expect existing pictures to at least contain imageUrl
               if (p && p.imageUrl) {
                 finalPictures.push({
                   imageUrl: p.imageUrl,
@@ -324,12 +310,9 @@ export class PropertyController {
               }
             }
           }
-        } catch (err) {
-          // ignore parse errors and continue with new uploads only
-        }
+        } catch (err) {}
       }
 
-      // Upload any new images and append
       if (propertyImages.length > 0) {
         const propertyPicturesData = request.body.propertyPictures
           ? JSON.parse(request.body.propertyPictures)

--- a/apps/api/src/services/category.service.ts
+++ b/apps/api/src/services/category.service.ts
@@ -2,39 +2,10 @@ import type { Prisma } from "@repo/database/generated/prisma/index.js";
 import { prisma } from "@repo/database";
 import { AppError } from "@/errors/app.error.js";
 import type {
-  CreatePropertyInput,
   CreateCustomCategoryInput,
   UpdateCustomCategoryInput,
   GetCategoriesQuery,
 } from "@repo/schemas";
-
-export async function resolveCategoryId(
-  tx: Prisma.TransactionClient,
-  data: CreatePropertyInput
-) {
-  const maybeId = (data as any).propertyCategoryId;
-  if (maybeId) return maybeId;
-
-  const incoming = (data as any).category;
-  if (incoming && typeof incoming === "object" && incoming.name) {
-    const name = String(incoming.name).trim();
-    const description = incoming.description
-      ? String(incoming.description).trim()
-      : undefined;
-
-    const { id } = await tx.propertyCategory.create({
-      data: {
-        name,
-        ...(description ? { description } : {}),
-      },
-      select: { id: true },
-    });
-
-    return id;
-  }
-
-  throw new AppError("Category is required", 400);
-}
 
 function paginate(query: GetCategoriesQuery) {
   const { page = 1, limit = 10, search } = query;

--- a/apps/web/src/components/tenant/property-creation/property-creation-context.tsx
+++ b/apps/web/src/components/tenant/property-creation/property-creation-context.tsx
@@ -41,7 +41,7 @@ type RoomFormData = {
 };
 
 type PropertyFormData = Partial<CreatePropertyInput> & {
-  selectedCategory?: "existing" | "custom" | "new";
+  selectedCategory?: "existing" | "custom";
   facilities?: Array<string | { facility: string; note?: string | null }>;
   pictures?: Array<PictureFormData>;
   rooms?: Array<RoomFormData>;
@@ -87,11 +87,7 @@ export function PropertyCreationProvider({
       case 2:
         return !!(formData.country && formData.city && formData.address);
       case 3:
-        return !!(
-          formData.propertyCategoryId ||
-          formData.customCategoryId ||
-          formData.customCategory
-        );
+        return !!formData.propertyCategoryId;
       case 4:
         return !!(formData.rooms && formData.rooms.length > 0);
       case 5:
@@ -111,11 +107,7 @@ export function PropertyCreationProvider({
         return (
           !!(formData.name && formData.description) &&
           !!(formData.country && formData.city && formData.address) &&
-          !!(
-            formData.propertyCategoryId ||
-            formData.customCategoryId ||
-            formData.customCategory
-          ) &&
+          !!formData.propertyCategoryId &&
           !!(formData.rooms && formData.rooms.length > 0) &&
           !!(
             formData.pictures &&
@@ -160,16 +152,16 @@ export function PropertyCreationProvider({
     if (formData.longitude)
       formDataToSend.append("longitude", String(formData.longitude));
 
-    // Handle category selection
-    if (formData.propertyCategoryId) {
-      formDataToSend.append("propertyCategoryId", formData.propertyCategoryId);
-    } else if (formData.customCategoryId) {
+    // Handle category selection (IDs only)
+    // Default category is required by the API
+    if (!formData.propertyCategoryId) {
+      toast.error("Please select a default category before continuing");
+      return;
+    }
+
+    formDataToSend.append("propertyCategoryId", formData.propertyCategoryId);
+    if (formData.customCategoryId) {
       formDataToSend.append("customCategoryId", formData.customCategoryId);
-    } else if (formData.customCategory) {
-      formDataToSend.append(
-        "customCategory",
-        JSON.stringify(formData.customCategory)
-      );
     }
 
     // Handle facilities

--- a/apps/web/src/components/tenant/property-creation/steps/category-step.tsx
+++ b/apps/web/src/components/tenant/property-creation/steps/category-step.tsx
@@ -8,9 +8,8 @@ import {
 } from "@/hooks/useCategories";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Building2, Check } from "lucide-react";
+import { Building2 } from "lucide-react";
 
 export function CategoryStep() {
   const { formData, updateFormData } = usePropertyCreation();
@@ -18,69 +17,42 @@ export function CategoryStep() {
     useCustomCategories();
   const { categories: defaultCategories, loading: defaultLoading } =
     useDefaultCategories();
-  const [selectedOption, setSelectedOption] = useState<
-    "default" | "custom" | "new"
-  >("default");
   const [selectedDefaultCategory, setSelectedDefaultCategory] =
     useState<string>("");
   const [selectedCustomCategory, setSelectedCustomCategory] =
     useState<string>("");
-  const [newCategoryName, setNewCategoryName] = useState("");
 
-  // Initialize selection based on existing form data
   useEffect(() => {
     if (formData.propertyCategoryId) {
-      setSelectedOption("default");
       setSelectedDefaultCategory(formData.propertyCategoryId);
-    } else if (formData.customCategoryId) {
-      setSelectedOption("custom");
+    }
+    if (formData.customCategoryId) {
       setSelectedCustomCategory(formData.customCategoryId);
-    } else if (formData.customCategory) {
-      setSelectedOption("new");
-      setNewCategoryName(formData.customCategory.name);
     }
   }, [formData]);
 
-  const handleOptionChange = (option: "default" | "custom" | "new") => {
-    setSelectedOption(option);
-
-    // Clear previous selections in form data
-    updateFormData({
-      propertyCategoryId: undefined,
-      customCategoryId: undefined,
-      customCategory: undefined,
-    });
-  };
-
   const handleDefaultCategorySelect = (categoryId: string) => {
-    setSelectedDefaultCategory(categoryId);
+    const next = selectedDefaultCategory === categoryId ? "" : categoryId;
+    setSelectedDefaultCategory(next);
+    const name = next
+      ? defaultCategories.find((c) => c.id === next)?.name
+      : undefined;
     updateFormData({
-      propertyCategoryId: categoryId,
-      customCategoryId: undefined,
-      customCategory: undefined,
+      propertyCategoryId: next || undefined,
+      propertyCategoryName: name,
     });
   };
 
   const handleCustomCategorySelect = (categoryId: string) => {
-    setSelectedCustomCategory(categoryId);
+    const next = selectedCustomCategory === categoryId ? "" : categoryId;
+    setSelectedCustomCategory(next);
+    const name = next
+      ? customCategories.find((c) => c.id === next)?.name
+      : undefined;
     updateFormData({
-      propertyCategoryId: undefined,
-      customCategoryId: categoryId,
-      customCategory: undefined,
+      customCategoryId: next || undefined,
+      customCategoryName: name,
     });
-  };
-
-  const handleNewCategoryChange = (name: string) => {
-    setNewCategoryName(name);
-    if (name.trim()) {
-      updateFormData({
-        propertyCategoryId: undefined,
-        customCategoryId: undefined,
-        customCategory: {
-          name: name.trim(),
-        },
-      });
-    }
   };
 
   return (
@@ -89,39 +61,8 @@ export function CategoryStep() {
         <CardTitle>Property Category</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
-        {/* Option Selection Buttons */}
-        <div className="flex flex-wrap gap-2">
-          <Button
-            type="button"
-            variant={selectedOption === "default" ? "default" : "outline"}
-            onClick={() => handleOptionChange("default")}
-            className="flex items-center gap-2"
-          >
-            {selectedOption === "default" && <Check className="w-4 h-4" />}
-            Default Categories
-          </Button>
-          <Button
-            type="button"
-            variant={selectedOption === "custom" ? "default" : "outline"}
-            onClick={() => handleOptionChange("custom")}
-            className="flex items-center gap-2"
-          >
-            {selectedOption === "custom" && <Check className="w-4 h-4" />}
-            My Categories
-          </Button>
-          <Button
-            type="button"
-            variant={selectedOption === "new" ? "default" : "outline"}
-            onClick={() => handleOptionChange("new")}
-            className="flex items-center gap-2"
-          >
-            {selectedOption === "new" && <Check className="w-4 h-4" />}
-            Create New
-          </Button>
-        </div>
-
         {/* Default Categories */}
-        {selectedOption === "default" && (
+        <div className="space-y-3">
           <div className="space-y-3">
             <Label className="text-base font-medium">Choose a category:</Label>
             {defaultLoading ? (
@@ -147,22 +88,18 @@ export function CategoryStep() {
               </div>
             )}
           </div>
-        )}
 
-        {/* Custom Categories */}
-        {selectedOption === "custom" && (
+          {/* Custom Categories */}
           <div className="space-y-3">
-            <Label className="text-base font-medium">
-              Choose from your categories:
-            </Label>
+            <Label className="text-base font-medium">My categories:</Label>
             {customLoading ? (
               <p className="text-sm text-gray-500">
                 Loading custom categories...
               </p>
             ) : customCategories.length === 0 ? (
               <p className="text-sm text-gray-500">
-                No custom categories yet. Create one by selecting &quot;Create
-                New&quot;!
+                No custom categories yet. Create them in the Categories
+                management page.
               </p>
             ) : (
               <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
@@ -185,26 +122,7 @@ export function CategoryStep() {
               </div>
             )}
           </div>
-        )}
-
-        {/* New Category */}
-        {selectedOption === "new" && (
-          <div className="space-y-4">
-            <Label className="text-base font-medium">
-              Create a new category:
-            </Label>
-
-            <div className="space-y-2">
-              <Label htmlFor="newCategoryName">Category Name *</Label>
-              <Input
-                id="newCategoryName"
-                value={newCategoryName}
-                onChange={(e) => handleNewCategoryChange(e.target.value)}
-                placeholder="e.g., Boutique Hotel"
-              />
-            </div>
-          </div>
-        )}
+        </div>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/components/tenant/property-creation/steps/review-step.tsx
+++ b/apps/web/src/components/tenant/property-creation/steps/review-step.tsx
@@ -23,6 +23,9 @@ import {
 export function ReviewStep() {
   const { formData, setCurrentStep } = usePropertyCreation();
 
+  const defaultName = formData.propertyCategoryName ?? null;
+  const customName = formData.customCategoryName ?? null;
+
   const getMaxGuestsFromRooms = (): number => {
     type RoomLike = { capacity?: number };
     const capacities = (formData.rooms || []).map((room: RoomLike) =>
@@ -49,17 +52,15 @@ export function ReviewStep() {
     },
     {
       label: "Category",
-      completed: !!(
-        formData.propertyCategoryId ||
-        formData.customCategoryId ||
-        formData.customCategory
-      ),
+      completed: !!(formData.propertyCategoryId || formData.customCategoryId),
       details: formData.propertyCategoryId
-        ? "Default category selected"
+        ? `Default category selected${
+            defaultName ? `: ${formData.propertyCategoryName}` : ""
+          }`
         : formData.customCategoryId
-        ? "Custom category selected"
-        : formData.customCategory
-        ? `New category: ${formData.customCategory.name}`
+        ? `Custom category selected${
+            customName ? `: ${formData.customCategoryName}` : ""
+          }`
         : "Not selected",
     },
     {
@@ -208,27 +209,20 @@ export function ReviewStep() {
               </Button>
             </div>
             <div className="ml-7">
-              {formData.propertyCategoryId && <p>Default category selected</p>}
-              {formData.customCategoryId && <p>Custom category selected</p>}
-              {formData.customCategory && (
-                <div>
-                  <p>
-                    <span className="font-medium">New Category:</span>{" "}
-                    {formData.customCategory.name}
-                  </p>
-                  {formData.customCategory.description && (
-                    <p>
-                      <span className="font-medium">Description:</span>{" "}
-                      {formData.customCategory.description}
-                    </p>
-                  )}
-                </div>
+              {formData.propertyCategoryId && (
+                <p>
+                  Default category selected
+                  {defaultName ? `: ${defaultName}` : ""}
+                </p>
               )}
-              {!formData.propertyCategoryId &&
-                !formData.customCategoryId &&
-                !formData.customCategory && (
-                  <p className="text-gray-500">Not selected</p>
-                )}
+              {formData.customCategoryId && (
+                <p>
+                  Custom category selected{customName ? `: ${customName}` : ""}
+                </p>
+              )}
+              {!formData.propertyCategoryId && !formData.customCategoryId && (
+                <p className="text-gray-500">Not selected</p>
+              )}
             </div>
           </div>
 

--- a/packages/schemas/src/property.schema.ts
+++ b/packages/schemas/src/property.schema.ts
@@ -90,17 +90,13 @@ export const createPropertyPictureSchema = z.object({
 export const createPropertyCategoryInput = z.union([
   z.object({ propertyCategoryId: z.uuid() }),
   z.object({ customCategoryId: z.uuid() }),
-  z.object({
-    customCategory: z.object({
-      name: z.string().min(1),
-      description: z.string().optional(),
-    }),
-  }),
 ]);
 
 export const createPropertyInputSchema = z
   .object({
     tenantId: z.uuid(),
+    propertyCategoryId: z.uuid().optional(),
+    customCategoryId: z.uuid().optional(),
     name: z.string().max(100),
     description: z.string(),
     country: z.string().max(60),
@@ -134,12 +130,6 @@ export const updatePropertyInputSchema = z.object({
   facilities: z.array(createFacilitySchema).optional(),
   propertyCategoryId: z.uuid().optional(),
   customCategoryId: z.uuid().optional(),
-  customCategory: z
-    .object({
-      name: z.string().min(1),
-      description: z.string().optional(),
-    })
-    .optional(),
 });
 
 export type CreatePropertyInput = z.infer<typeof createPropertyInputSchema>;


### PR DESCRIPTION
Backend

- Removed resolveCategoryId and related inline creation logic.
- API controllers now only accept propertyCategoryId or customCategoryId.

Frontend
- Property creation flow requires selecting an existing category by ID.
- Removed "Create New" option from category selection UI.

Schema & Review
- Property schema now only allows category IDs (no customCategory object).
- Review step updated to display the chosen category and remove inline creation references.