### PR TITLE
feat(property): remove facility notes & improve room image upload/preview

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -193,7 +193,6 @@ model PropertyFacility {
     id         String    @id @default(uuid())
     propertyId String
     facility   Amenities
-    note       String?   @db.Text
     createdAt  DateTime  @default(now())
 
     Property Property @relation(fields: [propertyId], references: [id], onDelete: Cascade)

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -241,9 +241,6 @@ async function seed() {
           data: chosen.map((facility) => ({
             propertyId: property.id,
             facility: facility as any,
-            note: faker.datatype.boolean()
-              ? faker.lorem.words({ min: 2, max: 6 })
-              : null,
           })),
         });
       }

--- a/apps/api/src/repositories/property.repository.ts
+++ b/apps/api/src/repositories/property.repository.ts
@@ -228,7 +228,6 @@ export class PropertyRepository {
       data: facilities.map((facility) => ({
         propertyId,
         facility: facility.facility,
-        note: facility.note,
       })),
     });
   }

--- a/apps/api/src/utils/mappers.ts
+++ b/apps/api/src/utils/mappers.ts
@@ -25,7 +25,6 @@ export function mapFacilities(facilities?: FacilityInput[]) {
   return {
     create: facilities.map((f) => ({
       facility: f.facility,
-      note: f.note ?? null,
     })),
   } as const;
 }

--- a/apps/web/src/components/tenant/edit-property-form.tsx
+++ b/apps/web/src/components/tenant/edit-property-form.tsx
@@ -124,7 +124,7 @@ export function EditPropertyForm({ propertyId }: EditPropertyFormProps) {
               property={property}
               onChange={(next) =>
                 setPropertyFacilities(
-                  next.map((f) => ({ facility: f.facility, note: f.note }))
+                  next.map((f) => ({ facility: f.facility }))
                 )
               }
             />

--- a/apps/web/src/components/tenant/edit-property-form/facilities-card.tsx
+++ b/apps/web/src/components/tenant/edit-property-form/facilities-card.tsx
@@ -17,11 +17,11 @@ export function FacilitiesCard({
   onChange,
 }: Props) {
   const toCreateFacility = (
-    f: string | { facility?: string; note?: string | null }
+    f: string | { facility?: string }
   ): CreateFacilityInput =>
     typeof f === "string"
-      ? { facility: f as AmenityType, note: null }
-      : { facility: (f.facility as string) || "", note: f.note || null };
+      ? { facility: f as AmenityType }
+      : { facility: (f.facility as string) || "" };
 
   const initial: CreateFacilityInput[] =
     controlledSelected ??
@@ -59,19 +59,11 @@ export function FacilitiesCard({
     if (isSelected) {
       updateSelected(selected.filter((f) => f.facility !== facility));
     } else {
-      updateSelected([
-        ...selected,
-        { facility: facility as AmenityType, note: null },
-      ]);
+      updateSelected([...selected, { facility: facility as AmenityType }]);
     }
   };
 
-  const handleNoteChange = (facility: string, note: string) => {
-    const updated = selected.map((f) =>
-      f.facility === facility ? { ...f, note: note || null } : f
-    );
-    updateSelected(updated);
-  };
+  // notes removed for facilities
 
   return (
     <Card>
@@ -88,7 +80,6 @@ export function FacilitiesCard({
         <FacilitiesEditor
           selected={selected}
           onToggle={handleFacilityToggle}
-          onNoteChange={handleNoteChange}
           query={query}
           setQuery={setQuery}
         />

--- a/apps/web/src/components/tenant/facilities-editor.tsx
+++ b/apps/web/src/components/tenant/facilities-editor.tsx
@@ -110,7 +110,6 @@ type FacilityItem = CreateFacilityInput;
 type Props = {
   selected: FacilityItem[];
   onToggle: (facility: string) => void;
-  onNoteChange: (facility: string, note: string) => void;
   query: string;
   setQuery: (q: string) => void;
 };
@@ -118,7 +117,6 @@ type Props = {
 export function FacilitiesEditor({
   selected,
   onToggle,
-  onNoteChange,
   query,
   setQuery,
 }: Props) {
@@ -178,17 +176,7 @@ export function FacilitiesEditor({
                       )}
                     </div>
 
-                    {isSelected && (
-                      <Input
-                        placeholder={`Optional note for ${FACILITY_LABELS[facility]}...`}
-                        value={
-                          selected.find((s) => s.facility === facility)?.note ||
-                          ""
-                        }
-                        onChange={(e) => onNoteChange(facility, e.target.value)}
-                        className="text-sm"
-                      />
-                    )}
+                    {/* notes removed for facilities */}
                   </div>
                 );
               })}

--- a/apps/web/src/components/tenant/property-creation/form-data-builder.ts
+++ b/apps/web/src/components/tenant/property-creation/form-data-builder.ts
@@ -65,9 +65,8 @@ const appendFacilities = (
   }
 
   const facilities = propertyData.facilities.map(
-    (facility: string | { facility: string; note?: string | null }) => ({
+    (facility: string | { facility: string }) => ({
       facility: typeof facility === "string" ? facility : facility.facility,
-      note: typeof facility === "object" ? facility.note : null,
     })
   );
 

--- a/apps/web/src/components/tenant/property-creation/types.ts
+++ b/apps/web/src/components/tenant/property-creation/types.ts
@@ -36,7 +36,7 @@ export type RoomFormData = {
 
 export type PropertyFormData = Partial<CreatePropertyInput> & {
   selectedCategory?: "existing" | "custom";
-  facilities?: Array<string | { facility: string; note?: string | null }>;
+  facilities?: Array<string | { facility: string }>;
   pictures?: Array<PictureFormData>;
   rooms?: Array<RoomFormData>;
 };

--- a/apps/web/src/hooks/useEditProperty.ts
+++ b/apps/web/src/hooks/useEditProperty.ts
@@ -62,12 +62,12 @@ export function useEditProperty(propertyId: string) {
   };
 
   const setPropertyFacilities = (
-    next: { facility: string; note?: string | null; id?: string }[] | null
+    next: { facility: string; id?: string }[] | null
   ) => {
     setProperty((prev: Property | null) => {
       if (!prev) return prev;
       const updated = Array.isArray(next)
-        ? next.map((f) => ({ facility: f.facility, note: f.note ?? null }))
+        ? next.map((f) => ({ facility: f.facility }))
         : [];
       return { ...prev, Facilities: updated } as Property;
     });

--- a/apps/web/src/lib/property/build-property-form-data.ts
+++ b/apps/web/src/lib/property/build-property-form-data.ts
@@ -31,13 +31,8 @@ export function buildPropertyFormData(
       "facilities",
       JSON.stringify(
         property.Facilities.map(
-          (facility: {
-            id: string;
-            facility: string;
-            note?: string | null;
-          }) => ({
+          (facility: { id: string; facility: string }) => ({
             facility: facility.facility,
-            note: facility.note,
           })
         )
       )

--- a/packages/schemas/src/facility.schema.ts
+++ b/packages/schemas/src/facility.schema.ts
@@ -30,7 +30,6 @@ export const amenitiesEnum = z.enum([
 
 export const createFacilitySchema = z.object({
   facility: amenitiesEnum,
-  note: z.string().optional().nullable(),
 });
 
 export type CreateFacilityInput = z.infer<typeof createFacilitySchema>;


### PR DESCRIPTION
Facility Notes Removal

- Dropped note field from PropertyFacility in Prisma schema and database.
- Removed facility note seeding, repository logic, and mapping.
- Removed note inputs and handlers from facility-related UI components.

Room Image Upload & Preview

- Added drag-and-drop and keyboard support for room image upload.
- Implemented preview caching to avoid memory leaks and unnecessary re-renders.
- Improved preview UI with larger images, better removal controls, and cleaner layout.

Misc

- Updated imports for React hooks to support new preview logic.