### PR TITLE
refactor(property-creation-wizard): simplify property creation wizard; add partial updates & localized price formatting

### DIFF
--- a/apps/web/src/components/tenant/basic-info-fields.tsx
+++ b/apps/web/src/components/tenant/basic-info-fields.tsx
@@ -6,8 +6,8 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 
 type Props = {
-  nameValue?: string;
-  descriptionValue?: string;
+  nameValue: string;
+  descriptionValue: string;
   onChange: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => void;
@@ -30,12 +30,10 @@ export function BasicInfoFields({
 
   return (
     <div className="space-y-6">
-      <div className="space-y-4">
-        <div className="flex items-center gap-3">
+      <div className="space-y-3">
+        <div className="flex items-center">
           <div>
-            <Label htmlFor="name" className="font-semibold text-foreground">
-              Property Name
-            </Label>
+            <Label htmlFor="name">Property Name</Label>
           </div>
         </div>
 
@@ -43,7 +41,7 @@ export function BasicInfoFields({
           <Input
             id="name"
             name="name"
-            value={nameValue ?? ""}
+            value={nameValue}
             onChange={onChange}
             placeholder="e.g., Luxury Beachfront Villa with Ocean Views"
             className="h-12 text-base border-2 border-slate-200 focus:ring-2 focus-visible:border-primary/50 focus-visible:ring-primary/10 transition-all duration-200"
@@ -84,15 +82,10 @@ export function BasicInfoFields({
         </div>
       </div>
 
-      <div className="space-y-2">
+      <div className="space-y-3">
         <div className="flex items-center">
           <div>
-            <Label
-              htmlFor="description"
-              className="font-semibold text-foreground"
-            >
-              Property Description
-            </Label>
+            <Label htmlFor="description">Property Description</Label>
           </div>
         </div>
 
@@ -100,7 +93,7 @@ export function BasicInfoFields({
           <Textarea
             id="description"
             name="description"
-            value={descriptionValue ?? ""}
+            value={descriptionValue}
             onChange={onChange}
             placeholder="Tell guests about your property's unique features, location highlights, amenities, and what makes it special..."
             rows={5}

--- a/apps/web/src/components/tenant/basic-info-fields.tsx
+++ b/apps/web/src/components/tenant/basic-info-fields.tsx
@@ -8,15 +8,17 @@ import { Textarea } from "@/components/ui/textarea";
 type Props = {
   nameValue: string;
   descriptionValue: string;
-  onChange: (
+  onChange?: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => void;
+  onUpdate?: (next: { name?: string; description?: string }) => void;
 };
 
 export function BasicInfoFields({
   nameValue,
   descriptionValue,
   onChange,
+  onUpdate,
 }: Props) {
   const nameProgress = useMemo(() => {
     const length = nameValue?.length || 0;
@@ -42,7 +44,13 @@ export function BasicInfoFields({
             id="name"
             name="name"
             value={nameValue}
-            onChange={onChange}
+            onChange={(e) => {
+              if (onChange) onChange(e);
+              if (onUpdate) {
+                const target = e.target as HTMLInputElement;
+                onUpdate({ name: target.value });
+              }
+            }}
             placeholder="e.g., Luxury Beachfront Villa with Ocean Views"
             className="h-12 text-base border-2 border-slate-200 focus:ring-2 focus-visible:border-primary/50 focus-visible:ring-primary/10 transition-all duration-200"
             maxLength={100}
@@ -94,7 +102,13 @@ export function BasicInfoFields({
             id="description"
             name="description"
             value={descriptionValue}
-            onChange={onChange}
+            onChange={(e) => {
+              if (onChange) onChange(e);
+              if (onUpdate) {
+                const target = e.target as HTMLTextAreaElement;
+                onUpdate({ description: target.value });
+              }
+            }}
             placeholder="Tell guests about your property's unique features, location highlights, amenities, and what makes it special..."
             rows={5}
             maxLength={500}

--- a/apps/web/src/components/tenant/edit-property-form/basic-info-card.tsx
+++ b/apps/web/src/components/tenant/edit-property-form/basic-info-card.tsx
@@ -13,9 +13,10 @@ type Props = {
   onChange: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => void;
+  onUpdate?: (next: { name?: string; description?: string }) => void;
 };
 
-export function BasicInfoCard({ values, onChange }: Props) {
+export function BasicInfoCard({ values, onChange, onUpdate }: Props) {
   return (
     <Card>
       <CardHeader className="mb-6">
@@ -32,6 +33,7 @@ export function BasicInfoCard({ values, onChange }: Props) {
           nameValue={values.name}
           descriptionValue={values.description}
           onChange={onChange}
+          onUpdate={onUpdate}
         />
       </CardContent>
     </Card>

--- a/apps/web/src/components/tenant/property-creation/property-creation-wizard.tsx
+++ b/apps/web/src/components/tenant/property-creation/property-creation-wizard.tsx
@@ -2,22 +2,14 @@
 
 import { PropertyCreationProvider } from "./property-creation-context";
 import { StepNavigation } from "./step-navigation";
-import {
-  WizardHeader,
-  WizardProgress,
-  WizardStepContent,
-  WizardStepHeader,
-} from "./wizard-layout";
+import { WizardHeader, WizardProgress } from "./wizard-layout";
 import { useWizardNavigation } from "./use-wizard-navigation";
 import { renderStepContent } from "./wizard-step-renderer";
-import { WIZARD_STEPS } from "./wizard-config";
 import PagerControls from "@/components/ui/pager-controls";
 
 function PropertyCreationWizardContent() {
   const {
     currentStep,
-    isTransitioning,
-    direction,
     canGoNext,
     canGoPrevious,
     isLastStep,
@@ -29,14 +21,8 @@ function PropertyCreationWizardContent() {
     transitionToStep,
   } = useWizardNavigation();
 
-  const currentStepData = WIZARD_STEPS.find((s) => s.number === currentStep)!;
-
   return (
     <div className="relative min-h-screen">
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute bottom-[-4rem] right-0 h-72 w-72 rounded-full bg-indigo-200/40 blur-3xl opacity-60 animate-in fade-in-50 delay-150" />
-      </div>
-
       <div className="relative max-w-6xl mx-auto space-y-8">
         <WizardHeader />
 
@@ -44,7 +30,6 @@ function PropertyCreationWizardContent() {
           <div className="bg-white/70 supports-[backdrop-filter]:bg-white/50 backdrop-blur-xl rounded-2xl shadow-lg border border-white/20 p-6 sm:p-8 ring-1 ring-black/5 animate-in fade-in-50 slide-in-from-top-2">
             <div className="space-y-6">
               <StepNavigation
-                steps={WIZARD_STEPS}
                 currentStep={currentStep}
                 onStepClick={transitionToStep}
                 isStepAccessible={hasStepData}
@@ -53,27 +38,18 @@ function PropertyCreationWizardContent() {
             </div>
           </div>
 
-          <WizardStepContent
-            isTransitioning={isTransitioning}
-            direction={direction}
-          >
-            <WizardStepHeader step={currentStepData} />
-            <div key={currentStep}>{renderStepContent(currentStep)}</div>
-          </WizardStepContent>
+          <div key={currentStep}>{renderStepContent(currentStep)}</div>
 
-          <div className="bg-white/70 supports-[backdrop-filter]:bg-white/50 backdrop-blur-xl rounded-2xl shadow-lg border border-white/20 p-4 sm:p-6 ring-1 ring-black/5 animate-in fade-in-50 slide-in-from-bottom-2">
-            <PagerControls
-              current={currentStep - 1}
-              maxIndex={WIZARD_STEPS.length - 1}
-              onPrev={handlePrevious}
-              onNext={handleNext}
-              onJump={handleJumpToStep}
-              canGoNext={canGoNext}
-              canGoPrev={canGoPrevious}
-              isLoading={isSubmitting}
-              nextLabel={isLastStep ? "Create Property" : undefined}
-            />
-          </div>
+          <PagerControls
+            current={currentStep - 1}
+            onPrev={handlePrevious}
+            onNext={handleNext}
+            onJump={handleJumpToStep}
+            canGoNext={canGoNext}
+            canGoPrev={canGoPrevious}
+            isLoading={isSubmitting}
+            nextLabel={isLastStep ? "Create Property" : undefined}
+          />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/tenant/property-creation/step-navigation.tsx
+++ b/apps/web/src/components/tenant/property-creation/step-navigation.tsx
@@ -2,18 +2,19 @@
 
 import { useCallback } from "react";
 import type { WizardStep } from "./wizard-config";
+import { WIZARD_STEPS } from "./wizard-config";
 import { DesktopStepNavigation } from "./desktop-step-navigation";
 import { MobileStepNavigation } from "./mobile-step-navigation";
 
 export interface StepNavigationProps {
-  steps: WizardStep[];
+  steps?: WizardStep[];
   currentStep: number;
   onStepClick?: (stepNumber: number) => void;
   isStepAccessible?: (stepNumber: number) => boolean;
 }
 
 export function StepNavigation({
-  steps,
+  steps = WIZARD_STEPS,
   currentStep,
   onStepClick,
   isStepAccessible,

--- a/apps/web/src/components/tenant/property-creation/steps/basic-info-step.tsx
+++ b/apps/web/src/components/tenant/property-creation/steps/basic-info-step.tsx
@@ -1,6 +1,10 @@
-import { usePropertyCreation } from "../property-creation-context";
-import BasicInfoFields from "@/components/tenant/basic-info-fields";
+"use client";
+
 import React from "react";
+import { usePropertyCreation } from "../property-creation-context";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { FileText } from "lucide-react";
+import BasicInfoFields from "@/components/tenant/basic-info-fields";
 
 export function BasicInfoStep() {
   const { formData, updateFormData } = usePropertyCreation();
@@ -13,12 +17,23 @@ export function BasicInfoStep() {
   };
 
   return (
-    <div className="space-y-8">
-      <BasicInfoFields
-        nameValue={formData.name}
-        descriptionValue={formData.description}
-        onChange={handleChange}
-      />
-    </div>
+    <Card>
+      <CardHeader className="mb-6">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <FileText className="h-5 w-5 text-primary" />
+          Basic Information
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Provide a name and short description for your property
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <BasicInfoFields
+          nameValue={formData.name ?? ""}
+          descriptionValue={formData.description ?? ""}
+          onChange={handleChange}
+        />
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/web/src/components/tenant/property-creation/steps/basic-info-step.tsx
+++ b/apps/web/src/components/tenant/property-creation/steps/basic-info-step.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { usePropertyCreation } from "../property-creation-context";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { FileText } from "lucide-react";
-import BasicInfoFields from "@/components/tenant/basic-info-fields";
+import BasicInfoCard from "@/components/tenant/basic-info-fields";
 
 export function BasicInfoStep() {
   const { formData, updateFormData } = usePropertyCreation();
@@ -14,6 +14,13 @@ export function BasicInfoStep() {
   ) => {
     const { name, value } = e.target as HTMLInputElement & HTMLTextAreaElement;
     updateFormData({ [name]: value });
+  };
+
+  const handlePartialUpdate = (next: {
+    name?: string;
+    description?: string;
+  }) => {
+    updateFormData(next);
   };
 
   return (
@@ -28,10 +35,11 @@ export function BasicInfoStep() {
         </p>
       </CardHeader>
       <CardContent className="space-y-6">
-        <BasicInfoFields
+        <BasicInfoCard
           nameValue={formData.name ?? ""}
           descriptionValue={formData.description ?? ""}
           onChange={handleChange}
+          onUpdate={handlePartialUpdate}
         />
       </CardContent>
     </Card>

--- a/apps/web/src/components/tenant/property-creation/steps/review-step.tsx
+++ b/apps/web/src/components/tenant/property-creation/steps/review-step.tsx
@@ -23,6 +23,15 @@ import {
 export function ReviewStep() {
   const { formData, setCurrentStep } = usePropertyCreation();
 
+  function formatPriceForDisplay(value: number | undefined | null) {
+    if (value === undefined || value === null || Number.isNaN(value))
+      return "0";
+    return new Intl.NumberFormat("id-ID", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+
   const defaultName = formData.propertyCategoryName ?? null;
   const customName = formData.customCategoryName ?? null;
 
@@ -79,49 +88,11 @@ export function ReviewStep() {
 
   return (
     <div className="space-y-6">
-      {/* Completion Status */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            {allCompleted ? (
-              <CheckCircle className="w-5 h-5 text-green-500" />
-            ) : (
-              <AlertCircle className="w-5 h-5 text-orange-500" />
-            )}
-            Completion Status
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {completionChecks.map((check, index) => (
-              <div key={index} className="flex items-start gap-3">
-                {check.completed ? (
-                  <CheckCircle className="w-5 h-5 text-green-500 mt-0.5" />
-                ) : (
-                  <AlertCircle className="w-5 h-5 text-orange-500 mt-0.5" />
-                )}
-                <div className="flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium">{check.label}</span>
-                    <Badge variant={check.completed ? "default" : "secondary"}>
-                      {check.completed ? "Complete" : "Incomplete"}
-                    </Badge>
-                  </div>
-                  <p className="text-sm text-gray-600 mt-1">{check.details}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Property Summary */}
       <Card>
         <CardHeader>
           <CardTitle>Property Summary</CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
-          {/* Basic Info */}
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <Building2 className="w-5 h-5 text-gray-500" />
@@ -154,7 +125,6 @@ export function ReviewStep() {
 
           <Separator />
 
-          {/* Location */}
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <MapPin className="w-5 h-5 text-gray-500" />
@@ -193,7 +163,6 @@ export function ReviewStep() {
 
           <Separator />
 
-          {/* Category */}
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <Building2 className="w-5 h-5 text-gray-500" />
@@ -228,7 +197,6 @@ export function ReviewStep() {
 
           <Separator />
 
-          {/* Rooms */}
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <Bed className="w-5 h-5 text-gray-500" />
@@ -264,7 +232,9 @@ export function ReviewStep() {
                         <p className="font-medium">{room.name}</p>
                         <div className="flex items-center gap-2">
                           <DollarSign className="w-4 h-4" />
-                          <span>${room.basePrice}/night</span>
+                          <span>
+                            Rp {formatPriceForDisplay(room.basePrice)}/night
+                          </span>
                         </div>
                       </div>
                       <div className="text-sm text-gray-600 mt-1">

--- a/apps/web/src/components/tenant/property-creation/use-wizard-navigation.ts
+++ b/apps/web/src/components/tenant/property-creation/use-wizard-navigation.ts
@@ -43,7 +43,6 @@ export function useWizardNavigation() {
       transitionTimeout.current = setTimeout(() => {
         setCurrentStep(nextStep);
 
-        // Small delay to ensure step content updates before removing transition state
         requestAnimationFrame(() => {
           setIsTransitioning(false);
           transitionTimeout.current = null;

--- a/apps/web/src/components/tenant/property-creation/wizard-layout.tsx
+++ b/apps/web/src/components/tenant/property-creation/wizard-layout.tsx
@@ -1,7 +1,4 @@
-import { ReactNode } from "react";
-import type { WizardStep } from "./wizard-config";
 import { Progress } from "@/components/ui/progress";
-import { cn } from "@/lib/utils";
 import { TOTAL_STEPS } from "./wizard-config";
 
 export function WizardHeader() {
@@ -45,53 +42,6 @@ export function WizardProgress({ currentStep }: WizardProgressProps) {
   );
 }
 
-interface WizardStepHeaderProps {
-  step: WizardStep;
-}
-export function WizardStepHeader({ step }: WizardStepHeaderProps) {
-  const Icon = step.icon;
+// Wizard step header removed — markup has been inlined where used.
 
-  return (
-    <div className="mb-3 sm:mb-4 flex flex-col gap-4">
-      <div className="flex items-start gap-3 sm:gap-4">
-        <div className="flex h-12 w-12 sm:h-14 sm:w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/10 to-primary/5 text-primary shadow-lg border border-primary/10">
-          <Icon className="h-6 w-6 sm:h-7 sm:w-7" />
-        </div>
-        <div className="space-y-2 flex-1">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <h2 className="text-lg sm:text-xl font-bold tracking-tight text-gray-900">
-              {step.title}
-            </h2>
-          </div>
-          <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed">
-            {step.description}
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-interface WizardStepContentProps {
-  children: ReactNode;
-  isTransitioning: boolean;
-  direction: "forward" | "backward";
-}
-export function WizardStepContent({
-  children,
-  isTransitioning,
-}: WizardStepContentProps) {
-  return (
-    <div
-      className={cn(
-        "bg-white/80 supports-[backdrop-filter]:bg-white/60 backdrop-blur-xl rounded-2xl shadow-lg border border-white/30 min-h-[500px] sm:min-h-[600px] p-4 sm:p-6 lg:p-8 ring-1 ring-black/5 transition-opacity duration-200",
-        {
-          "opacity-0": isTransitioning,
-          "opacity-100": !isTransitioning,
-        }
-      )}
-    >
-      {children}
-    </div>
-  );
-}
+// Wizard step content wrapper removed — container markup has been inlined where used.

--- a/apps/web/src/components/ui/pager-controls.tsx
+++ b/apps/web/src/components/ui/pager-controls.tsx
@@ -2,9 +2,11 @@
 
 import React from "react";
 
+import { TOTAL_STEPS } from "@/components/tenant/property-creation/wizard-config";
+
 type Props = {
   current: number;
-  maxIndex: number;
+  maxIndex?: number;
   onPrev: () => void;
   onNext: () => void;
   className?: string;
@@ -18,7 +20,7 @@ type Props = {
 
 export default function PagerControls({
   current,
-  maxIndex,
+  maxIndex = Math.max(TOTAL_STEPS - 1, 0),
   onPrev,
   onNext,
   className = "",


### PR DESCRIPTION
- Refactor basic info to support full/partial updates via optional onUpdate, separating UI from data logic.
- Streamline wizard layout & nav by removing WizardStepHeader/Content, inlining markup, and using WIZARD_STEPS defaults.
- Improve review UX with localized room price formatting and a tighter summary (removed completion card).
- Pager controls now derive total steps from wizard config by default.
- Minor cleanup: removed a redundant comment in navigation transition.