### PR TITLE
refactor(api, web): split auth logic into controllers/services and enhance sign-in UX

### DIFF
--- a/apps/api/src/controllers/authentication.controller.ts
+++ b/apps/api/src/controllers/authentication.controller.ts
@@ -1,0 +1,176 @@
+import {
+  LoginSchema,
+  ForgotPasswordSchema,
+  ResetPasswordWithTokenSchema,
+  changePasswordSchema,
+} from "@repo/schemas";
+import { NextFunction, Request, Response } from "express";
+import { AuthenticationService } from "@/services/authentication.service.js";
+import { PasswordResetService } from "@/services/password.service.js";
+import {
+  UpdateUserSchema,
+  changeEmailRequestSchema,
+  changeEmailSchema,
+} from "@repo/schemas";
+import { FileService } from "@/services/file.service.js";
+
+export class AuthenticationController {
+  private authenticationService = new AuthenticationService();
+  private passwordResetService = new PasswordResetService();
+  private fileService = new FileService();
+
+  login = async (request: Request, response: Response, next: NextFunction) => {
+    try {
+      const data = LoginSchema.parse(request.body);
+      const result = await this.authenticationService.login(data);
+      response.status(200).json({
+        message: "User logged in successfully",
+        data: result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  requestPasswordReset = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { email } = ForgotPasswordSchema.parse(request.body);
+      await this.passwordResetService.requestPasswordReset(email);
+      response.status(200).json({ message: "Password reset email sent" });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  resetPassword = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const data = ResetPasswordWithTokenSchema.parse(request.body);
+      await this.passwordResetService.resetPasswordWithToken(data);
+      response.status(200).json({ message: "Password changed successfully" });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  changePassword = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const data = changePasswordSchema.parse(request.body);
+      await this.authenticationService.changePassword(request.user.id, data);
+      response.status(200).json({ message: "Password changed successfully" });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getProfile = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const userId = request.user.id;
+      const userProfile = await this.authenticationService.getUserProfile(
+        userId
+      );
+      response.status(200).json({
+        message: "User profile fetched successfully",
+        data: userProfile,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getUserByEmail = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const email = String(request.query.email || "");
+      if (!email) {
+        response.status(400).json({ message: "Email is required" });
+        return;
+      }
+      const user = await this.authenticationService.getUserByEmail(email);
+      response
+        .status(200)
+        .json({ message: "User fetched successfully", data: user });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  updateProfile = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const profilePicture = request.file
+        ? await this.fileService.uploadPicture(request.file.path)
+        : undefined;
+
+      const data = UpdateUserSchema.parse({
+        ...request.body,
+        image: profilePicture,
+      });
+
+      const updatedUser = await this.authenticationService.updateProfile(
+        request.user.id,
+        data
+      );
+
+      response
+        .status(200)
+        .json({ message: "Profile updated successfully", user: updatedUser });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  requestChangeEmail = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { newEmail } = changeEmailRequestSchema.parse(request.body);
+      await this.authenticationService.requestChangeEmail(
+        request.user.id,
+        newEmail
+      );
+      response.status(200).json({ message: "Email change verification sent" });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  confirmChangeEmail = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { token } = changeEmailSchema.parse(request.body);
+      await this.authenticationService.confirmChangeEmail(token);
+      response.status(200).json({ message: "Email changed successfully" });
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+export const authenticationController = new AuthenticationController();

--- a/apps/api/src/controllers/registration.controller.ts
+++ b/apps/api/src/controllers/registration.controller.ts
@@ -1,0 +1,68 @@
+import {
+  RegistrationStartSchema,
+  CompleteRegistrationSchema,
+  OAuthUserSchema,
+} from "@repo/schemas";
+import { NextFunction, Request, Response } from "express";
+import { RegistrationService } from "@/services/registration.service.js";
+import { FileService } from "@/services/file.service.js";
+
+export class RegistrationController {
+  private registrationService = new RegistrationService();
+  private fileService = new FileService();
+
+  startRegistration = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const data = RegistrationStartSchema.parse(request.body);
+      await this.registrationService.startRegistration(data);
+      response.status(200).json({ message: "Verification email sent" });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  upsertUser = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const data = OAuthUserSchema.parse(request.body);
+      const result = await this.registrationService.upsertOAuthUser(data);
+      response.status(200).json({
+        message: "OAuth login successful",
+        data: result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  completeRegistration = async (
+    request: Request,
+    response: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const profilePicture = request.file
+        ? await this.fileService.uploadPicture(request.file.path)
+        : undefined;
+
+      const data = CompleteRegistrationSchema.parse({
+        ...request.body,
+        image: profilePicture,
+      });
+
+      await this.registrationService.completeRegistration(data);
+      response.status(200).json({ message: "Registration completed" });
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+export const registrationController = new RegistrationController();

--- a/apps/api/src/routers/auth.router.ts
+++ b/apps/api/src/routers/auth.router.ts
@@ -1,38 +1,45 @@
 import { Router } from "express";
-import { authController } from "../controllers/auth.controller.js";
+import { registrationController } from "../controllers/registration.controller.js";
+import { authenticationController } from "../controllers/authentication.controller.js";
 import { upload } from "@/middlewares/upload.middleware.js";
 import { verifyTokenMiddleware } from "@/middlewares/verifyToken.middleware.js";
 
 const router = Router();
-router.post("/signup", authController.startRegistration);
+router.post("/signup", registrationController.startRegistration);
 router.post(
   "/signup/complete",
   upload.single("image"),
-  authController.completeRegistration
+  registrationController.completeRegistration
 );
-router.post("/signin", authController.userLogin);
-router.post("/forgot-password", authController.requestPasswordReset);
-router.post("/reset-password", authController.resetPassword);
-router.get("/profile", verifyTokenMiddleware, authController.getProfile);
-router.get("/user", authController.getUserByEmail);
-router.post("/oauth", authController.oauthUpsertUser);
+router.post("/signin", authenticationController.login);
+router.post("/forgot-password", authenticationController.requestPasswordReset);
+router.post("/reset-password", authenticationController.resetPassword);
+router.put(
+  "/change-password",
+  verifyTokenMiddleware,
+  authenticationController.changePassword
+);
+router.get(
+  "/profile",
+  verifyTokenMiddleware,
+  authenticationController.getProfile
+);
+router.get("/user", authenticationController.getUserByEmail);
 router.put(
   "/profile",
   verifyTokenMiddleware,
   upload.single("image"),
-  authController.editProfile
+  authenticationController.updateProfile
 );
-router.put(
-  "/change-password",
-  verifyTokenMiddleware,
-  authController.changePassword
-);
-
 router.post(
   "/change-email",
   verifyTokenMiddleware,
-  authController.requestChangeEmail
+  authenticationController.requestChangeEmail
 );
-router.post("/change-email/confirm", authController.confirmChangeEmail);
+router.post(
+  "/change-email/confirm",
+  authenticationController.confirmChangeEmail
+);
+router.post("/oauth", registrationController.upsertUser);
 
 export default router;

--- a/apps/api/src/services/authentication.service.ts
+++ b/apps/api/src/services/authentication.service.ts
@@ -1,0 +1,154 @@
+import { prisma } from "@/configs/prisma.config.js";
+import {
+  LoginInput,
+  ChangePasswordInput,
+  UpdateUserInput,
+} from "@repo/schemas";
+import { AppError } from "@/errors/app.error.js";
+import { generateToken, verifyToken } from "@/utils/jwt.js";
+import { EmailService } from "./email.service.js";
+import { TokenService } from "./token.service.js";
+import bcrypt from "bcrypt";
+
+export class AuthenticationService {
+  private emailService = new EmailService();
+  private tokenService = new TokenService();
+  private static readonly VERIFY_TTL_MS = 60 * 60 * 1000;
+  async login(data: LoginInput) {
+    const user = await prisma.user.findUnique({ where: { email: data.email } });
+
+    if (!user) throw new AppError("Invalid email or password", 401);
+    if (!user.emailVerified) throw new AppError("Email not verified", 403);
+    if (!user.password) throw new AppError("Invalid email or password", 401);
+
+    const isValidPassword = await bcrypt.compare(data.password, user.password);
+    if (!isValidPassword) throw new AppError("Invalid email or password", 401);
+
+    const token = generateToken(
+      {
+        id: user.id,
+        name: user.firstName,
+        email: user.email,
+        image: user.image,
+        role: user.role,
+      },
+      "7d"
+    );
+
+    return { accessToken: token };
+  }
+
+  async changePassword(userId: string, data: ChangePasswordInput) {
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+
+    if (!user) throw new AppError("User not found", 404);
+    if (!user.password) throw new AppError("Password not set", 400);
+
+    const isValidPassword = await bcrypt.compare(
+      data.currentPassword,
+      user.password
+    );
+    if (!isValidPassword) throw new AppError("Invalid current password", 401);
+
+    const hashedPassword = await bcrypt.hash(data.newPassword, 10);
+
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { password: hashedPassword },
+    });
+
+    return { ok: true };
+  }
+
+  async requestChangeEmail(userId: string, newEmail: string) {
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+
+    if (!user) throw new AppError("User not found", 404);
+    if (!user.emailVerified) throw new AppError("Email not verified", 400);
+
+    const existing = await prisma.user.findUnique({
+      where: { email: newEmail },
+    });
+    if (existing) throw new AppError("Email already in use", 409);
+
+    const token = await this.tokenService.generateEmailToken(
+      user.id,
+      "EMAIL_CHANGE",
+      AuthenticationService.VERIFY_TTL_MS,
+      { newEmail }
+    );
+
+    await this.emailService.sendEmailChangeVerification(newEmail, token);
+
+    return { ok: true };
+  }
+
+  async confirmChangeEmail(token: string) {
+    const ver = await this.tokenService.verifyEmailToken(token, "EMAIL_CHANGE");
+
+    const payload = verifyToken(token) as {
+      id: string;
+      purpose: string;
+      newEmail?: string;
+    };
+    if (!payload.newEmail) throw new AppError("Invalid token payload", 400);
+
+    const user = await prisma.user.findUnique({ where: { id: ver.userId } });
+    if (!user) throw new AppError("User not found", 404);
+
+    const emailTaken = await prisma.user.findUnique({
+      where: { email: payload.newEmail },
+    });
+    if (emailTaken) throw new AppError("Email already in use", 409);
+
+    await prisma.$transaction([
+      prisma.user.update({
+        where: { id: user.id },
+        data: { email: payload.newEmail },
+      }),
+      prisma.authToken.update({
+        where: { id: ver.id },
+        data: { usedAt: new Date(), status: "USED" },
+      }),
+    ]);
+
+    return { ok: true };
+  }
+
+  async getUserProfile(userId: string) {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      omit: { password: true, createdAt: true, updatedAt: true },
+    });
+
+    if (!user) throw new AppError("User not found", 404);
+
+    return user;
+  }
+
+  async getUserByEmail(email: string) {
+    const user = await prisma.user.findUnique({
+      where: { email },
+      omit: { password: true, createdAt: true, updatedAt: true },
+    });
+
+    if (!user) throw new AppError("User not found", 404);
+
+    return user;
+  }
+
+  async updateProfile(userId: string, data: Partial<UpdateUserInput>) {
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+
+    if (!user) throw new AppError("User not found", 404);
+
+    const updatedUser = await prisma.user.update({
+      where: { id: userId },
+      data: {
+        ...data,
+      },
+    });
+
+    return updatedUser;
+  }
+}

--- a/apps/api/src/services/registration.service.ts
+++ b/apps/api/src/services/registration.service.ts
@@ -1,0 +1,129 @@
+import { prisma } from "@/configs/prisma.config.js";
+import {
+  RegistrationStartInput,
+  CompleteRegistrationInput,
+} from "@repo/schemas";
+import { AppError } from "@/errors/app.error.js";
+import { EmailService } from "./email.service.js";
+import { TokenService } from "./token.service.js";
+import { OAuthUserInput } from "@repo/schemas";
+import { generateToken } from "@/utils/jwt.js";
+import bcrypt from "bcrypt";
+
+export class RegistrationService {
+  private emailService = new EmailService();
+  private tokenService = new TokenService();
+  private static readonly VERIFY_TTL_MS = 60 * 60 * 1000;
+
+  async startRegistration(input: RegistrationStartInput) {
+    const { email, role } = input;
+
+    const user =
+      (await prisma.user.findUnique({ where: { email } })) ??
+      (await prisma.user.create({ data: { email, firstName: "", role } }));
+
+    if (user.emailVerified) throw new AppError("User already exists", 409);
+
+    const token = await this.tokenService.generateEmailToken(
+      user.id,
+      "EMAIL_VERIFICATION",
+      RegistrationService.VERIFY_TTL_MS
+    );
+
+    await this.emailService.sendEmailVerification(email, token);
+
+    return { ok: true };
+  }
+
+  async completeRegistration(input: CompleteRegistrationInput) {
+    const { token, firstName, lastName, phone, image, password } = input;
+
+    const ver = await this.tokenService.verifyEmailToken(
+      token,
+      "EMAIL_VERIFICATION"
+    );
+
+    const user = await prisma.user.findUnique({ where: { id: ver.userId } });
+
+    if (!user) throw new AppError("User not found", 404);
+    if (user.emailVerified) throw new AppError("Email already verified", 400);
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    await prisma.$transaction([
+      prisma.user.update({
+        where: { id: user.id },
+        data: {
+          firstName,
+          lastName,
+          phone,
+          image,
+          password: hashedPassword,
+          emailVerified: new Date(),
+        },
+      }),
+      prisma.authToken.update({
+        where: { id: ver.id },
+        data: { usedAt: new Date(), status: "USED" },
+      }),
+    ]);
+
+    return { ok: true };
+  }
+
+  async upsertOAuthUser(input: OAuthUserInput) {
+    const email = input.email;
+    const existing = await prisma.user.findUnique({ where: { email } });
+    const desiredRole = input.role ?? "GUEST";
+
+    if (existing && desiredRole === "TENANT" && existing.role !== "TENANT") {
+      throw new AppError("Email already registered as guest", 409);
+    }
+
+    const nameFromInput = input.name?.trim();
+    const [firstName, lastName] = nameFromInput?.split(" ") ?? [];
+    const now = new Date();
+
+    const user = existing
+      ? await prisma.user.update({
+          where: { id: existing.id },
+          data: {
+            firstName,
+            lastName,
+            name: nameFromInput,
+            image: input.image,
+            role: desiredRole === "TENANT" ? "TENANT" : undefined,
+            emailVerified: existing.emailVerified ? undefined : now,
+          },
+        })
+      : await prisma.user.create({
+          data: {
+            email,
+            firstName,
+            lastName,
+            name: nameFromInput,
+            image: input.image,
+            role: desiredRole,
+            emailVerified: new Date(),
+          },
+        });
+
+    const accessToken = generateToken(
+      {
+        id: user.id,
+        name: user.name ?? user.firstName ?? user.email,
+        email: user.email,
+        image: user.image,
+        role: user.role,
+      },
+      "7d"
+    );
+
+    const { password: _password, ...userWithoutPassword } = user;
+
+    return {
+      user: userWithoutPassword,
+      accessToken,
+    };
+  }
+}

--- a/apps/web/src/app/(auth)/signin/page.tsx
+++ b/apps/web/src/app/(auth)/signin/page.tsx
@@ -24,7 +24,7 @@ function GuestSignContent() {
         <AuthHeader
           title="Sign in"
           caption="Don't have an account?"
-          link={`/signup${
+          link={`/guest-signup${
             callbackUrl !== "/dashboard"
               ? `?callbackUrl=${encodeURIComponent(callbackUrl)}`
               : ""
@@ -33,7 +33,7 @@ function GuestSignContent() {
         />
         <SignInForm
           title="Sign in"
-          signupref={`/signup${
+          signupref={`/guest-signup${
             callbackUrl !== "/dashboard"
               ? `?callbackUrl=${encodeURIComponent(callbackUrl)}`
               : ""

--- a/apps/web/src/components/auth/complete-profile-form.tsx
+++ b/apps/web/src/components/auth/complete-profile-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useCallback, useState } from "react";
+import { useCallback, useState, ChangeEvent } from "react";
+import { FiEye, FiEyeOff } from "react-icons/fi";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -26,6 +27,9 @@ interface Props {
 export default function CompleteProfileForm({ token }: Props) {
   const router = useRouter();
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
+    useState(false);
 
   const {
     register,
@@ -36,24 +40,21 @@ export default function CompleteProfileForm({ token }: Props) {
     defaultValues: { token },
   });
 
-  const onSelectAvatar = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (!file) {
-        setAvatarFile(null);
-        return;
-      }
-      const error = validateAvatar(file);
-      if (error) {
-        toast.error(error);
-        e.target.value = "";
-        setAvatarFile(null);
-        return;
-      }
-      setAvatarFile(file);
-    },
-    []
-  );
+  const onSelectAvatar = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) {
+      setAvatarFile(null);
+      return;
+    }
+    const error = validateAvatar(file);
+    if (error) {
+      toast.error(error);
+      e.target.value = "";
+      setAvatarFile(null);
+      return;
+    }
+    setAvatarFile(file);
+  }, []);
 
   const onSubmit = useCallback(
     async (data: CompleteRegistrationClientInput) => {
@@ -110,26 +111,58 @@ export default function CompleteProfileForm({ token }: Props) {
       </div>
       <div className="space-y-2">
         <Label htmlFor="password">Password</Label>
-        <Input
-          id="password"
-          type="password"
-          disabled={isSubmitting}
-          required
-          {...register("password")}
-        />
+        <div className="relative">
+          <Input
+            id="password"
+            type={isPasswordVisible ? "text" : "password"}
+            disabled={isSubmitting}
+            required
+            {...register("password")}
+          />
+          <button
+            type="button"
+            aria-label={isPasswordVisible ? "Hide password" : "Show password"}
+            onClick={() => setIsPasswordVisible((v) => !v)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground cursor-pointer"
+            disabled={isSubmitting}
+          >
+            {isPasswordVisible ? (
+              <FiEyeOff className="w-4 h-4" />
+            ) : (
+              <FiEye className="w-4 h-4" />
+            )}
+          </button>
+        </div>
         {errors.password && (
           <p className="text-xs text-red-500">{errors.password.message}</p>
         )}
       </div>
       <div className="space-y-2">
         <Label htmlFor="confirmPassword">Confirm Password</Label>
-        <Input
-          id="confirmPassword"
-          type="password"
-          disabled={isSubmitting}
-          required
-          {...register("confirmPassword")}
-        />
+        <div className="relative">
+          <Input
+            id="confirmPassword"
+            type={isConfirmPasswordVisible ? "text" : "password"}
+            disabled={isSubmitting}
+            required
+            {...register("confirmPassword")}
+          />
+          <button
+            type="button"
+            aria-label={
+              isConfirmPasswordVisible ? "Hide password" : "Show password"
+            }
+            onClick={() => setIsConfirmPasswordVisible((v) => !v)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground cursor-pointer"
+            disabled={isSubmitting}
+          >
+            {isConfirmPasswordVisible ? (
+              <FiEyeOff className="w-4 h-4" />
+            ) : (
+              <FiEye className="w-4 h-4" />
+            )}
+          </button>
+        </div>
         {errors.confirmPassword && (
           <p className="text-xs text-red-500">
             {errors.confirmPassword.message}


### PR DESCRIPTION
***Backend (API)***

- Split authController into AuthenticationController and RegistrationController for better separation of concerns.
- Added AuthenticationService and RegistrationService to handle business logic like login, registration, and OAuth.
- Updated auth.router.ts to use the new controllers and reorganized endpoints.

***Frontend (Web)***

- Fixed sign-in links to route guest users to /guest-signup.
- Added password visibility toggles on the complete profile form for better usability.